### PR TITLE
Typos n bugfixes

### DIFF
--- a/tyk-pro/scripts/bootstrap_k8s.sh
+++ b/tyk-pro/scripts/bootstrap_k8s.sh
@@ -179,10 +179,12 @@ output(){
   echo "User: $2"
   echo "Pass: $3"
 
-  cp $PWD/tyk-pro/scripts/secret_tpl.yaml $PWD/tyk-pro/scripts/secrets.yaml
-  B64_ORGID=$(echo -n $ORGID | base64)
-  B64_CODE=$(echo -n $USER_AUTH_CODE | base64)
-  sed -e "s/\${namespace}/$NS/" -e "s/\${ORGID}/$B64_ORGID/" -e "s/\${USER_AUTH_CODE}/$B64_CODE/" -i $PWD/tyk-pro/scripts/secrets.yaml
+  INFILE = ${PWD}/tyk-pro/scripts/secret_tpl.yaml
+  OUTFILE = ${PWD}/tyk-pro/scripts/secrets.yaml
+  B64_ORGID = $(echo -n ${ORGID} | base64)
+  B64_CODE = $(echo -n ${USER_AUTH_CODE} | base64)
+
+  sed -e "s/\${namespace}/${NS}/" -e "s/\${ORGID}/${B64_ORGID}/" -e "s/\${USER_AUTH_CODE}/${B64_CODE}/" ${INFILE} > ${OUTFILE}
 }
 
 main $1 $2

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -22,4 +22,4 @@ helm install -f ./values.yaml ./tyk-k8s
 
 5. Register the sidecar-injector
 
-kubectl create -f ./tyk-k8s/webhook/mutatingwebhook-ca-bundle.yamn
+kubectl create -f ./tyk-k8s/webhook/mutatingwebhook-ca-bundle.yaml

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -3,7 +3,7 @@ Run the following in bash to bootstrap the dashboard instance:
 1. Bootstrap the dashboard so we can get a username and password to login, this also generates access tokens for the controller to use
 
 export NODE_PORT=$(kubectl get --namespace {{ .Values.nameSpace }} -o jsonpath="{.spec.ports[0].nodePort}" services dashboard-svc-{{ include "tyk-pro.fullname" . }})
-export NODE_IP=$(kubectl get nodes --selector=kubernetes.io/role!=master -o jsonpath={.items[0].status.addresses[?\(@.type==\"ExternalIP\"\)].address})
+export NODE_IP=$(kubectl get nodes --selector=kubernetes.io/role!=master -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
 export DASH_URL=http://$NODE_IP:$NODE_PORT
 ./tyk-pro/scripts/bootstrap_k8s.sh $NODE_IP:$NODE_PORT {{ .Values.secrets.AdminSecret }} {{ .Values.nameSpace }}
 


### PR DESCRIPTION
Use of `sed -i` has different syntax across operating systems. This fix redirects output of `sed` to new file rather than taking a copy of the template and modifying the copy in-line.

Tweaking NOTES.txt to put jsonpath in quotes and avoid having to escape. Resolves issue on OSX

fixed typo of file extension in NOTES.txt
