### PR TITLE
Fixes resource values reference and some strings not being quoted for the env vars

### DIFF
--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -49,7 +49,7 @@ spec:
           - name: TYK_DB_REDISSSLINSECURESKIPVERIFY
             value: "true"
           - name: TYK_DB_MONGOURL
-            value: "{{ .Values.mongo.mongoURL }}"
+            value: {{ .Values.mongo.mongoURL | quote }}
           - name: TYK_DB_MONGOUSESSL
             value: "{{ .Values.mongo.useSSL }}"
           - name: TYK_DB_ADMINSECRET
@@ -57,9 +57,9 @@ spec:
           - name: TYK_DB_NODESECRET
             value: "{{ .Values.secrets.APISecret }}"
           - name: TYK_DB_LICENSEKEY
-            value: "{{ .Values.dash.license }}"
+            value: {{ .Values.dash.license | quote }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.dash.resources | indent 12 }}
         command: ["/opt/tyk-dashboard/tyk-analytics", "--conf=/etc/tyk-dashboard/tyk_analytics.conf"]
         workingDir: /opt/tyk-dashboard
         ports:

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -55,7 +55,7 @@ spec:
         ports:
         - containerPort: 443
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.gateway.resources | indent 12 }}
         volumeMounts:
           - name: tyk-mgmt-gateway-conf
             mountPath: /etc/tyk-gateway

--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -29,11 +29,11 @@ spec:
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"
           - name: PMP_MONGO_MONGOURL
-            value: "{{ .Values.mongo.mongoURL }}"
+            value: {{ .Values.mongo.mongoURL | quote }}
           - name: PMP_MONGO_MONGOUSESSL
             value: "{{ .Values.mongo.useSSL }}"
           - name: PMP_MONGOAGG_MONGOURL
-            value:  "{{ .Values.mongo.mongoURL }}"
+            value:  {{ .Values.mongo.mongoURL | quote }}
           - name: PMP_MONGOAGG_MONGOUSESSL
             value:  "{{ .Values.mongo.useSSL }}"
           - name: TYK_PMP_REDIS_HOSTS
@@ -43,7 +43,7 @@ spec:
           - name: tyk-pump-conf
             mountPath: /etc/tyk-pump
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.pump.resources | indent 12 }}
       volumes:
         - name: tyk-pump-conf
           configMap:


### PR DESCRIPTION
Specifying resource requests and limits had no effect and some strings woudn't be properly set to the env vars.