### PR TITLE
Fixed copy paste typo for community install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To get started quickly, you can use these rather excellent Redis and MongoDB cha
 ## Install Tyk Community Edition
 To install, *first modify the `values_community_edition.yaml` file to add redis details*:
 
-	helm install -f ./values_community_edition.yaml ./tyk-pro
+	helm install -f ./values_community_edition.yaml ./tyk-headless
 
 > **Warning**: Tyk Service Mesh capability is not currently supported with Tyk CE
 


### PR DESCRIPTION
The readme said to install tyk-pro for community edition. This led to a failed install because of a missmatch between community values and pro install.