### PR TITLE
Updates resources, brings watchNamespaces, controller certs gen optional, fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ output.yaml
 tyk-pro/old_tpl
 values_real.yaml
 tyk-k8s/templates/secrets.yaml
+tyk-pro/scripts/secrets.yaml

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ It also means that you can bring the full features set of the Tyk API Gateway to
 
 To get started quickly, you can use these rather excellent Redis and MongoDB charts to get going:
 
-	helm repo add tc http://trusted-charts.stackpoint.io
+	helm repo add stable https://kubernetes-charts.storage.googleapis.com
 	helm repo update
-	helm install tc/redis --name redis --namespace=redis --set usePassword=false
-	helm install tc/mongodb-replicaset --name mongodb --namespace=mongodb 
+	kubectl create namespace tyk-ingress
+	helm install tyk-mongo stable/mongodb --set "replicaSet.enabled=true" -n tyk-ingress
+	(follow notes from the installation output to get connection details)
+	helm install tyk-redis stable/redis -n tyk-ingress
+	(follow notes from the installation output to get connection details)
 
 > *Important Note regarding TLS:* This helm chart assumes TLS is being used by default, so the gateways will listen on port 443 and load up a dummy certificate. You can set your own default certificate by replacing the files in the certs/ folder.
 
@@ -27,14 +30,14 @@ To get started quickly, you can use these rather excellent Redis and MongoDB cha
 
 To install, *first modify the `values_community_edition.yaml` file to add redis details*:
 
-	helm install -f ./values_community_edition.yaml ./tyk-headless
+	helm install tyk-ce -f ./values_community_edition.yaml ./tyk-headless -n tyk-ingress
 
 > **Warning**: Tyk Service Mesh capability is not currently supported with Tyk CE
 
 ## Install Tyk Pro
 To install, *first modify the `values.yaml` file to add redis and mongo details, and add your license*:
 
-	helm install -f ./values.yaml ./tyk-pro
+	helm install tyk-pro -f ./values.yaml ./tyk-pro -n tyk-ingress
 
 Follow the instructions in the Notes that follow the installation to install the controller for Service Mesh sidecar injection.
 

--- a/tyk-headless/scripts/secret_tpl.yaml
+++ b/tyk-headless/scripts/secret_tpl.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: tyk-k8s-controller
-  namespace: ${namespace}
-type: Opaque
-data:
-  secret: ${USER_AUTH_CODE}
-  org: ${ORGID}

--- a/tyk-headless/templates/configmap-tyk-k8s.yaml
+++ b/tyk-headless/templates/configmap-tyk-k8s.yaml
@@ -9,10 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   tyk_k8s.yaml: |-
-    Server:
-      addr: ":9595"
-      certFile: ""
-      keyFile: ""
+    Ingress:
+      watchNamespaces:
+{{ toYaml .Values.tyk_k8s.watchNamespaces | indent 8 }}
     Tyk:
       url: "https://localhost:9696"
       secret: "set-by-env"

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -1,20 +1,20 @@
 {{ if .Values.rbac }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    name: tyk-k8s
+  name: tyk-k8s
 rules:
-- apiGroups: ["extensions"]
-  resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses", "ingresses/status"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["namespaces", "configmaps", "pods", "endpoints", "services"]
-  verbs: ["get", "list"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: ["ingresses/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "pods", "endpoints", "services"]
+    verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tyk-k8s
@@ -45,6 +45,19 @@ spec:
 {{- if eq .Values.gateway.kind "Deployment" }}
   replicas: {{ .Values.gateway.replicaCount }}
 {{- end }}
+  minReadySeconds: 5
+{{- if eq .Values.gateway.kind "Deployment" }}
+  strategy:
+{{- else }}
+  updateStrategy:
+{{- end }}
+    # indicate which strategy we want for rolling update
+    type: RollingUpdate
+    rollingUpdate:
+{{- if eq .Values.gateway.kind "Deployment" }}
+      maxSurge: 2
+{{- end }}
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: gateway-{{ include "tyk-headless.fullname" . }}
@@ -56,13 +69,6 @@ spec:
         release: {{ .Release.Name }}
     spec:
       {{ if .Values.rbac }}serviceAccountName: tyk-k8s {{ end }}
-      minReadySeconds: 20
-      strategy:
-        # indicate which strategy we want for rolling update
-        type: RollingUpdate
-        rollingUpdate:
-          maxSurge: 2
-          maxUnavailable: 1
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.gateway.nodeSelector | indent 8 }}
@@ -105,7 +111,7 @@ spec:
         ports:
         - containerPort: 8080
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.gateway.resources | indent 12 }}
         volumeMounts:
           - name: tyk-mgmt-gateway-conf
             mountPath: /etc/tyk-gateway
@@ -122,12 +128,11 @@ spec:
             value: "{{ .Values.secrets.APISecret }}"
           - name: TK8S_TYK_ORG
             value: "{{ .Values.secrets.OrgID }}"
-        
         volumeMounts:
           - name: tyk-k8s-conf
             mountPath: /etc/tyk-k8s
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.tyk_k8s.resources | indent 12 }}
       volumes:
         - name: tyk-k8s-conf
           configMap:

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -86,6 +86,8 @@ spec:
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         env:
+          - name: TYK_GW_LISTENPORT
+            value: "{{ .Values.gateway.containerPort }}"
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"
           - name: TYK_GW_STORAGE_HOSTS
@@ -109,7 +111,7 @@ spec:
         command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
         workingDir: /opt/tyk-gateway
         ports:
-        - containerPort: 8080
+        - containerPort: {{ .Values.gateway.containerPort }}
         resources:
 {{ toYaml .Values.gateway.resources | indent 12 }}
         volumeMounts:
@@ -117,6 +119,24 @@ spec:
             mountPath: /etc/tyk-gateway
           - name: {{ .Release.Name }}-default-cert
             mountPath: /etc/certs
+        livenessProbe:
+          httpGet:
+            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
+            path: /hello
+            port: {{ .Values.gateway.containerPort }}
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 3
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
+            path: /hello
+            port: {{ .Values.gateway.containerPort }}
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
 
       - name: tyk-k8s
         image: "{{ .Values.tyk_k8s.image.repository }}:{{ .Values.tyk_k8s.image.tag }}"
@@ -131,24 +151,6 @@ spec:
         volumeMounts:
           - name: tyk-k8s-conf
             mountPath: /etc/tyk-k8s
-        livenessProbe:
-          httpGet:
-            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
-            path: /hello
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 2
-          timeoutSeconds: 3
-          failureThreshold: 2
-        readinessProbe:
-          httpGet:
-            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
-            path: /hello
-            port: 8080
-          initialDelaySeconds: 1
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
         resources:
 {{ toYaml .Values.tyk_k8s.resources | indent 12 }}
       volumes:

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -131,6 +131,24 @@ spec:
         volumeMounts:
           - name: tyk-k8s-conf
             mountPath: /etc/tyk-k8s
+        livenessProbe:
+          httpGet:
+            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
+            path: /hello
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 3
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
+            path: /hello
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
         resources:
 {{ toYaml .Values.tyk_k8s.resources | indent 12 }}
       volumes:

--- a/tyk-headless/templates/deployment-pmp.yaml
+++ b/tyk-headless/templates/deployment-pmp.yaml
@@ -47,11 +47,11 @@ spec:
             value:  "{{ .Values.mongo.mongoURL }}"
           - name: PMP_MONGOAGG_MONGOUSESSL
             value:  "{{ .Values.mongo.useSSL }}"
-          - name: TYK_PMP_REDIS_HOSTS
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_HOSTS
             value: "{{ .Values.redis.host }}:{{ .Values.redis.port }}"
-          - name: TYK_PMP_REDIS_PASSWORD
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_PASSWORD
             value: "{{ .Values.redis.pass }}"
-          - name: TYK_PMP_REDIS_REDISUSESSL
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_REDISUSESSL
             value: "{{ .Values.redis.useSSL }}"
         {{- if .Values.pump.extraEnvs }}
         {{- range $env := .Values.pump.extraEnvs }}

--- a/tyk-headless/templates/service-gw.yaml
+++ b/tyk-headless/templates/service-gw.yaml
@@ -17,7 +17,7 @@ spec:
   type: {{ .Values.gateway.service.type }}
   ports:
   - port: {{ .Values.gateway.service.port }}
-    targetPort: 8080
+    targetPort: {{ .Values.gateway.containerPort }}
     protocol: TCP
   selector:
     app: gateway-{{ include "tyk-headless.fullname" . }}

--- a/tyk-hybrid/templates/NOTES.txt
+++ b/tyk-hybrid/templates/NOTES.txt
@@ -1,13 +1,4 @@
-1. Prepare the SSL and CA bundle for webhook
+Install the controller
 
-./tyk-k8s/webhook/create-signed-cert.sh -n {{ .Release.Namespace }}
-
-cat ./tyk-k8s/webhook/mutatingwebhook.yaml | ./tyk-k8s/webhook/webhook-patch-ca-bundle.sh > ./tyk-k8s/webhook/mutatingwebhook-ca-bundle.yaml
-
-2. Install the controller
-
-helm install -f ./values_hybrid.yaml ./tyk-k8s
-
-3. Register the sidecar-injector
-
-kubectl create -f ./tyk-k8s/webhook/mutatingwebhook-ca-bundle.yaml
+Use your own values file and optionally release name to install the controller chart:
+helm install tyk-controller -f ./values_hybrid.yaml ./tyk-k8s -n {{ .Release.Namespace }}

--- a/tyk-hybrid/templates/configmap-tyk-k8s.yaml
+++ b/tyk-hybrid/templates/configmap-tyk-k8s.yaml
@@ -9,10 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   tyk_k8s.yaml: |-
-    Server:
-      addr: ":443"
-      certFile: "/etc/tyk-k8s/certs/cert.pem"
-      keyFile: "/etc/tyk-k8s/certs/key.pem"
+    Ingress:
+      watchNamespaces:
+{{ toYaml .Values.tyk_k8s.watchNamespaces | indent 8 }}
     Tyk:
       url: "{{ .Values.tyk_k8s.dash_url }}"
       secret: "{{ .Values.tyk_k8s.dash_key }}"

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -51,6 +51,8 @@ spec:
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         env:
+          - name: TYK_GW_LISTENPORT
+            value: "{{ .Values.gateway.containerPort }}"
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"
           - name: TYK_GW_STORAGE_HOSTS
@@ -86,7 +88,7 @@ spec:
         command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
         workingDir: /opt/tyk-gateway
         ports:
-        - containerPort: 8080
+        - containerPort: {{ .Values.gateway.containerPort }}
         resources:
 {{ toYaml .Values.gateway.resources | indent 12 }}
         volumeMounts:
@@ -98,7 +100,7 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
-            port: 8080
+            port: {{ .Values.gateway.containerPort }}
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 3
@@ -107,7 +109,7 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
-            port: 8080
+            port: {{ .Values.gateway.containerPort }}
           initialDelaySeconds: 1
           periodSeconds: 10
           timeoutSeconds: 3

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -94,6 +94,24 @@ spec:
             mountPath: /etc/tyk-gateway
           - name: {{ .Release.Name }}-default-cert
             mountPath: /etc/certs
+        livenessProbe:
+          httpGet:
+            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
+            path: /hello
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 3
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
+            path: /hello
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
       volumes:
         - name: hybrid-gateway-conf
           configMap:

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -11,6 +11,19 @@ spec:
 {{- if eq .Values.gateway.kind "Deployment" }}
   replicas: {{ .Values.gateway.replicaCount }}
 {{- end }}
+  minReadySeconds: 10
+{{- if eq .Values.gateway.kind "Deployment" }}
+  strategy:
+{{- else }}
+  updateStrategy:
+{{- end }}
+    # indicate which strategy we want for rolling update
+    type: RollingUpdate
+    rollingUpdate:
+{{- if eq .Values.gateway.kind "Deployment" }}
+      maxSurge: 2
+{{- end }}
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: gateway-{{ include "tyk-hybrid.fullname" . }}
@@ -21,13 +34,6 @@ spec:
         app: gateway-{{ include "tyk-hybrid.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      minReadySeconds: 20
-      strategy:
-        # indicate which strategy we want for rolling update
-        type: RollingUpdate
-        rollingUpdate:
-          maxSurge: 2
-          maxUnavailable: 1
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.gateway.nodeSelector | indent 8 }}

--- a/tyk-hybrid/templates/service-gw.yaml
+++ b/tyk-hybrid/templates/service-gw.yaml
@@ -17,7 +17,7 @@ spec:
   type: {{ .Values.gateway.service.type }}
   ports:
   - port: {{ .Values.gateway.service.port }}
-    targetPort: 8080
+    targetPort: {{ .Values.gateway.containerPort }}
     protocol: TCP
   selector:
     app: gateway-{{ include "tyk-hybrid.fullname" . }}

--- a/tyk-k8s/templates/deployment-tyk-k8s.yaml
+++ b/tyk-k8s/templates/deployment-tyk-k8s.yaml
@@ -1,38 +1,4 @@
-{{ if .Values.rbac }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-    name: tyk-k8s
-rules:
-- apiGroups: ["extensions"]
-  resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses", "ingresses/status"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["namespaces", "configmaps", "pods", "endpoints", "services"]
-  verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: tyk-k8s
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tyk-k8s
-subjects:
-  - kind: ServiceAccount
-    name: tyk-k8s
-    namespace: {{ .Release.Namespace }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tyk-k8s
----{{ end }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tyk-k8s
@@ -43,6 +9,13 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  minReadySeconds: 5
+  strategy:
+    # indicate which strategy we want for rolling update
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: tyk-k8s
@@ -54,13 +27,25 @@ spec:
         release: {{ .Release.Name }}
     spec:
       {{ if .Values.rbac }}serviceAccountName: tyk-k8s {{ end }}
+{{- if .Values.tyk_k8s.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.tyk_k8s.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tyk_k8s.tolerations }}
+      tolerations:
+{{ toYaml .Values.tyk_k8s.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.tyk_k8s.affinity }}
+      affinity:
+{{ toYaml .Values.tyk_k8s.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: tyk-k8s
         image: "{{ .Values.tyk_k8s.image.repository }}:{{ .Values.tyk_k8s.image.tag }}"
         imagePullPolicy: {{ .Values.tyk_k8s.image.pullPolicy }}
         workingDir: "/opt/tyk-k8s"
         command: ["/opt/tyk-k8s/tyk-k8s", "start"]
-        {{ if not .Values.hybrid }}
+        {{- if not .Values.hybrid }}
         env:
           - name: TK8S_TYK_SECRET
             valueFrom:
@@ -72,16 +57,18 @@ spec:
               secretKeyRef:
                 name: tyk-k8s-controller
                 key: org
-        {{ end }}
+        {{- end }}
         ports:
         - containerPort: 443
         volumeMounts:
           - name: tyk-k8s-conf
             mountPath: /etc/tyk-k8s
+          {{- if .Values.tyk_k8s.serviceMesh.enabled }}
           - name: webhook-certs
             mountPath: /etc/tyk-k8s/certs
+          {{- end }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.tyk_k8s.resources | indent 12 }}
       volumes:
         - name: tyk-k8s-conf
           configMap:
@@ -89,6 +76,9 @@ spec:
             items:
               - key: tyk_k8s.yaml
                 path: tyk-k8s.yaml
+        {{- if .Values.tyk_k8s.serviceMesh.enabled }}
         - name: webhook-certs
           secret:
             secretName: sidecar-injector-webhook-certs
+        {{- end }}
+

--- a/tyk-k8s/templates/deployment-tyk-k8s.yaml
+++ b/tyk-k8s/templates/deployment-tyk-k8s.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.tyk_k8s.replicaCount }}
   minReadySeconds: 5
   strategy:
     # indicate which strategy we want for rolling update

--- a/tyk-k8s/templates/rbac.yaml
+++ b/tyk-k8s/templates/rbac.yaml
@@ -1,0 +1,34 @@
+{{ if .Values.rbac }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tyk-k8s
+rules:
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: ["ingresses/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "pods", "endpoints", "services"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tyk-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tyk-k8s
+subjects:
+  - kind: ServiceAccount
+    name: tyk-k8s
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tyk-k8s
+{{ end }}

--- a/tyk-pro/scripts/bootstrap_k8s.sh
+++ b/tyk-pro/scripts/bootstrap_k8s.sh
@@ -121,7 +121,7 @@ if_present_echo(){
 }
 
 create_organisation() {
-  ORGDATA=$(curl --silent --header "admin-auth: $ADMIN_TOKEN" --header "Content-Type:application/json" --data '{"owner_name": "Default Org.","owner_slug": "default", "cname_enabled": true, "cname": ""}' ${SCHEMA_OPT}://$1/admin/organisations 2>&1)
+  ORGDATA=$(curl -k --silent --header "admin-auth: $ADMIN_TOKEN" --header "Content-Type:application/json" --data '{"owner_name": "Default Org.","owner_slug": "default", "cname_enabled": true, "cname": ""}' ${SCHEMA_OPT}://$1/admin/organisations 2>&1)
   if_present_echo "$ORGDATA" 3
 }
 
@@ -138,7 +138,7 @@ create_user(){
 }
 
 user_data(){
-  user_curl=$(curl --silent --header "admin-auth: $ADMIN_TOKEN" --header "Content-Type:application/json" --data '{"first_name": "Joan","last_name": "Smith","email_address": "'$2'@default.com","password":"'$3'", "active": true,"org_id": "'$4'"}' ${SCHEMA_OPT}://$1/admin/users 2>&1)
+  user_curl=$(curl -k --silent --header "admin-auth: $ADMIN_TOKEN" --header "Content-Type:application/json" --data '{"first_name": "Joan","last_name": "Smith","email_address": "'$2'@default.com","password":"'$3'", "active": true,"org_id": "'$4'"}' ${SCHEMA_OPT}://$1/admin/users 2>&1)
   if_present_echo $user_curl 3
 }
 
@@ -149,7 +149,7 @@ get_user(){
 }
 
 get_user_list(){
-  list=$(curl --silent --header "authorization: $2" ${SCHEMA_OPT}://$1/api/users 2>&1)
+  list=$(curl -k --silent --header "authorization: $2" ${SCHEMA_OPT}://$1/api/users 2>&1)
   if_present_echo "$list" 3
 }
 
@@ -173,7 +173,7 @@ get_last_user(){
 setting_password(){
   USER=$(get_user $1 $2)
   USERID=$(get_user_id "$USER")
-  response=$(curl --silent --header "authorization: $2" --header "Content-Type:application/json" ${SCHEMA_OPT}://$1/api/users/$USERID/actions/reset --data '{"new_password":"'$3'"}')
+  response=$(curl -k --silent --header "authorization: $2" --header "Content-Type:application/json" ${SCHEMA_OPT}://$1/api/users/$USERID/actions/reset --data '{"new_password":"'$3'"}')
   if_present_echo "$response" 3
 }
 

--- a/tyk-pro/scripts/bootstrap_k8s.sh
+++ b/tyk-pro/scripts/bootstrap_k8s.sh
@@ -126,14 +126,14 @@ create_organisation() {
 }
 
 org_id(){
-  ORGID=$(echo $1 | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Meta"]')
+  ORGID=$(echo $1 | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["Meta"])')
   if_present_echo $ORGID 4
 }
 
 
 create_user(){
   USER_DATA=$(user_data $1 $2 $3 $4)
-  AUTH_CODE=$(echo $USER_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Message"]')
+  AUTH_CODE=$(echo $USER_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["Message"])')
   if_present_echo "$AUTH_CODE" 4
 }
 
@@ -155,18 +155,18 @@ get_user_list(){
 
 get_user_id(){
   export user=$1
-  id=$(python -c "import json,os,string;user_str=os.environ['user'];print json.loads(user_str)['id']")
+  id=$(python -c "import json,os,string;user_str=os.environ['user'];print(json.loads(user_str)['id'])")
   if_present_echo "$id" 4
 }
 
 get_user_email(){
   export user=$1
-  email=$(python -c "import json,os,string;user_str=os.environ['user'];print json.loads(user_str)['email_address']")
+  email=$(python -c "import json,os,string;user_str=os.environ['user'];print(json.loads(user_str)['email_address'])")
   if_present_echo "$email" 4
 }
 
 get_last_user(){
-  user_parsed=$(echo $1 | python -c 'import json,sys;obj=json.load(sys.stdin);print json.dumps(obj["users"][0])')
+  user_parsed=$(echo $1 | python -c 'import json,sys;obj=json.load(sys.stdin);print(json.dumps(obj["users"][0]))')
   if_present_echo "$user_parsed" 4
 }
 

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -4,6 +4,10 @@ Run the following in bash to bootstrap the dashboard instance:
 
 export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services dashboard-svc-{{ include "tyk-pro.fullname" . }})
 export NODE_IP=$(kubectl get nodes --selector=kubernetes.io/role!=master -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
+
+If you're using minikube, run this instead:
+export NODE_IP=$(minikube ip)
+
 export DASH_URL=http://$NODE_IP:$NODE_PORT
 
 1a. You may need to open up that port in your firewall so that we can access the dashboard. Example in GCloud
@@ -14,19 +18,22 @@ gcloud compute firewall-rules create dashboard --allow tcp:$NODE_PORT
 
 ./tyk-pro/scripts/bootstrap_k8s.sh $NODE_IP:$NODE_PORT {{ .Values.secrets.AdminSecret }} {{ .Release.Namespace }}
 
+At this point, Tyk Pro is fully installed and should be accessible, proceed in case you want to install Tyk ingress controller.
+
 2. Move the encoded secrets to the controller helm chart
 
 mv ./tyk-pro/scripts/secrets.yaml ./tyk-k8s/templates
 
-3. Prepare the SSL and CA bundle for webhook
+3. Prepare the SSL and CA bundle for webhook (only necessary for Service Mesh functionality)
 
 ./tyk-k8s/webhook/create-signed-cert.sh -n {{ .Release.Namespace }}
 cat ./tyk-k8s/webhook/mutatingwebhook.yaml | ./tyk-k8s/webhook/webhook-patch-ca-bundle.sh > ./tyk-k8s/webhook/mutatingwebhook-ca-bundle.yaml
 
 4. Install the controller
 
-helm install -f ./values.yaml ./tyk-k8s
+Use your own values file and optionally release name to install the controller chart:
+helm install tyk-controller -f ./values.yaml ./tyk-k8s -n {{ .Release.Namespace }}
 
-5. Register the sidecar-injector
+5. Register the sidecar-injector (only necessary for Service Mesh functionality)
 
 kubectl create -f ./tyk-k8s/webhook/mutatingwebhook-ca-bundle.yaml

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -2,13 +2,19 @@ Run the following in bash to bootstrap the dashboard instance:
 
 1. Bootstrap the dashboard so we can get a username and password to login, this also generates access tokens for the controller to use
 
+{{- if .Values.dash.ingress.enabled }}
+export DASH_URL="{{ .Values.dash.hostName }}"
+export DASH_HTTPS="{{ if gt (len .Values.dash.ingress.tls) 0 }}1{{ end }}"
+{{- else }}
 export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services dashboard-svc-{{ include "tyk-pro.fullname" . }})
 export NODE_IP=$(kubectl get nodes --selector=kubernetes.io/role!=master -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
 
 If you're using minikube, run this instead:
 export NODE_IP=$(minikube ip)
 
-export DASH_URL=http://$NODE_IP:$NODE_PORT
+export DASH_URL="$NODE_IP:$NODE_PORT"
+export DASH_HTTPS=""
+{{- end }}
 
 1a. You may need to open up that port in your firewall so that we can access the dashboard. Example in GCloud
 
@@ -16,7 +22,7 @@ gcloud compute firewall-rules create dashboard --allow tcp:$NODE_PORT
 
 1b. Bootstrap the dashboard
 
-./tyk-pro/scripts/bootstrap_k8s.sh $NODE_IP:$NODE_PORT {{ .Values.secrets.AdminSecret }} {{ .Release.Namespace }}
+./tyk-pro/scripts/bootstrap_k8s.sh $DASH_URL {{ .Values.secrets.AdminSecret }} {{ .Release.Namespace }} $DASH_HTTPS
 
 At this point, Tyk Pro is fully installed and should be accessible, proceed in case you want to install Tyk ingress controller.
 

--- a/tyk-pro/templates/configmap-tyk-k8s.yaml
+++ b/tyk-pro/templates/configmap-tyk-k8s.yaml
@@ -9,14 +9,20 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   tyk_k8s.yaml: |-
+    {{- if .Values.tyk_k8s.serviceMesh.enabled }}
     Server:
       addr: ":443"
       certFile: "/etc/tyk-k8s/certs/cert.pem"
       keyFile: "/etc/tyk-k8s/certs/key.pem"
+    {{- end }}
+    Ingress:
+      watchNamespaces:
+{{ toYaml .Values.tyk_k8s.watchNamespaces | indent 8 }}
     Tyk:
       url: "http://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
       secret: "set-by-env"
       org: "set-by-env"
+    {{- if .Values.tyk_k8s.serviceMesh.enabled }}
     Injector:
       createRoutes: true
       containers:
@@ -52,3 +58,4 @@ data:
             privileged: true
           command:
             - "/entrypoint"
+    {{- end }}

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -47,6 +47,8 @@ spec:
             value: "{{ .Values.redis.shardCount }}"
           - name: TYK_DB_HOSTCONFIG_HOSTNAME
             value: "{{ .Values.dash.hostName }}"
+          - name: TYK_DB_HOSTCONFIG_GATEWAYHOSTNAME
+            value: "{{ .Values.gateway.hostName }}"
           - name: TYK_DB_TYKAPI_HOST
             value: "{{ include "tyk-pro.gwproto" . }}://gateway-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
           - name: TYK_DB_TYKAPI_PORT
@@ -86,6 +88,24 @@ spec:
         volumeMounts:
           - name: tyk-dashboard-conf
             mountPath: /etc/tyk-dashboard
+        livenessProbe:
+          httpGet:
+            scheme: "HTTP"
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 3
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            scheme: "HTTP"
+            path: /
+            port: 3000
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
       volumes:
         - name: tyk-dashboard-conf
           configMap:

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -9,6 +9,13 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.dash.replicaCount }}
+  minReadySeconds: 5
+  strategy:
+    # indicate which strategy we want for rolling update
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: dashboard-{{ include "tyk-pro.fullname" . }}
@@ -19,13 +26,6 @@ spec:
         app: dashboard-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      minReadySeconds: 20
-      strategy:
-        # indicate which strategy we want for rolling update
-        type: RollingUpdate
-        rollingUpdate:
-          maxSurge: 2
-          maxUnavailable: 1
 {{- if .Values.dash.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.dash.nodeSelector | indent 8 }}

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -43,6 +43,8 @@ spec:
         imagePullPolicy: {{ .Values.dash.image.pullPolicy }}
         name: dashboard-{{ .Chart.Name }}
         env:
+          - name: TYK_DB_LISTENPORT
+            value: "{{ .Values.dash.containerPort }}"
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"
           - name: TYK_DB_HOSTCONFIG_HOSTNAME
@@ -84,7 +86,7 @@ spec:
         command: ["/opt/tyk-dashboard/tyk-analytics", "--conf=/etc/tyk-dashboard/tyk_analytics.conf"]
         workingDir: /opt/tyk-dashboard
         ports:
-        - containerPort:  3000
+        - containerPort: {{ .Values.dash.containerPort }}
         volumeMounts:
           - name: tyk-dashboard-conf
             mountPath: /etc/tyk-dashboard
@@ -92,7 +94,7 @@ spec:
           httpGet:
             scheme: "HTTP"
             path: /
-            port: 3000
+            port: {{ .Values.dash.containerPort }}
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 3
@@ -101,7 +103,7 @@ spec:
           httpGet:
             scheme: "HTTP"
             path: /
-            port: 3000
+            port: {{ .Values.dash.containerPort }}
           initialDelaySeconds: 1
           periodSeconds: 10
           timeoutSeconds: 3

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -11,6 +11,19 @@ spec:
 {{- if eq .Values.gateway.kind "Deployment" }}
   replicas: {{ .Values.gateway.replicaCount }}
 {{- end }}
+  minReadySeconds: 10
+{{- if eq .Values.gateway.kind "Deployment" }}
+  strategy:
+{{- else }}
+  updateStrategy:
+{{- end }}
+    # indicate which strategy we want for rolling update
+    type: RollingUpdate
+    rollingUpdate:
+{{- if eq .Values.gateway.kind "Deployment" }}
+      maxSurge: 2
+{{- end }}
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: gateway-{{ include "tyk-pro.fullname" . }}
@@ -21,13 +34,6 @@ spec:
         app: gateway-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      minReadySeconds: 20
-      strategy:
-        # indicate which strategy we want for rolling update
-        type: RollingUpdate
-        rollingUpdate:
-          maxSurge: 2
-          maxUnavailable: 1
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.gateway.nodeSelector | indent 8 }}

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -51,6 +51,8 @@ spec:
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         env:
+          - name: TYK_GW_LISTENPORT
+            value: "{{ .Values.gateway.containerPort }}"
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"
           - name: TYK_GW_STORAGE_HOSTS
@@ -70,7 +72,7 @@ spec:
           - name: TYK_GW_NODESECRET
             value: "{{ .Values.secrets.APISecret }}"
           - name: TYK_GW_DBAPPCONFOPTIONS_TAGS
-            value: "{{.Values.gateway.tags }}"
+            value: "{{ .Values.gateway.tags }}"
           - name: TYK_GW_HTTPSERVEROPTIONS_USESSL
             value: "{{ .Values.gateway.tls }}"
         {{- if .Values.gateway.extraEnvs }}
@@ -82,7 +84,7 @@ spec:
         command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
         workingDir: /opt/tyk-gateway
         ports:
-        - containerPort: 8080
+        - containerPort: {{ .Values.gateway.containerPort }}
         resources:
 {{ toYaml .Values.gateway.resources | indent 12 }}
         volumeMounts:
@@ -94,7 +96,7 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
-            port: 8080
+            port: {{ .Values.gateway.containerPort }}
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 3
@@ -103,7 +105,7 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
-            port: 8080
+            port: {{ .Values.gateway.containerPort }}
           initialDelaySeconds: 1
           periodSeconds: 10
           timeoutSeconds: 3

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -90,6 +90,24 @@ spec:
             mountPath: /etc/tyk-gateway
           - name: {{ .Release.Name }}-default-cert
             mountPath: /etc/certs
+        livenessProbe:
+          httpGet:
+            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
+            path: /hello
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 3
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
+            path: /hello
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
       volumes:
         - name: tyk-mgmt-gateway-conf
           configMap:

--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -53,11 +53,11 @@ spec:
             value:  {{ .Values.mongo.mongoURL | quote }}
           - name: PMP_MONGOAGG_MONGOUSESSL
             value:  "{{ .Values.mongo.useSSL }}"
-          - name: TYK_PMP_REDIS_HOSTS
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_HOSTS
             value: "{{ .Values.redis.host }}:{{ .Values.redis.port }}"
-          - name: TYK_PMP_REDIS_PASSWORD
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_PASSWORD
             value: "{{ .Values.redis.pass }}"
-          - name: TYK_PMP_REDIS_REDISUSESSL
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_REDISUSESSL
             value: "{{ .Values.redis.useSSL }}"
         {{- if .Values.pump.extraEnvs }}
         {{- range $env := .Values.pump.extraEnvs }}

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -44,6 +44,8 @@ spec:
         imagePullPolicy: {{ .Values.tib.image.pullPolicy }}
         name: tib-{{ .Chart.Name }}
         env:
+          - name: TYK_IB_PORT
+            value: "{{ .Values.tib.containerPort }}"
           - name: TYK_IB_SECRET
             value: "{{ .Values.tib.secret }}"
           - name: TYK_IB_HTTPSERVEROPTIONS_USESSL
@@ -53,7 +55,7 @@ spec:
           - name: TYK_IB_TYKAPISETTINGS_GATEWAYCONFIG_ENDPOINT
             value: "{{ include "tyk-pro.gwproto" . }}://gateway-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
           - name: TYK_IB_TYKAPISETTINGS_GATEWAYCONFIG_PORT
-            value: "8080"
+            value: "{{ .Values.gateway.service.port }}"
           - name: TYK_IB_TYKAPISETTINGS_GATEWAYCONFIG_ADMINSECRET
             value: "{{ .Values.secrets.AdminSecret }}"
           - name: TYK_IB_TYKAPISETTINGS_DASHBOARDCONFIG_ENDPOINT
@@ -69,7 +71,7 @@ spec:
         resources:
 {{ toYaml .Values.tib.resources | indent 10 }}
         ports:
-        - containerPort:  {{ .Values.tib.service.port }}
+        - containerPort: {{ .Values.tib.containerPort }}
         volumeMounts:
           - name: tyk-tib-conf-volume
             mountPath: /opt/tyk-identity-broker/tib.conf
@@ -83,7 +85,7 @@ spec:
           httpGet:
             scheme: "HTTP"
             path: /health
-            port: {{ .Values.tib.service.port }}
+            port: {{ .Values.tib.containerPort }}
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 3
@@ -92,7 +94,7 @@ spec:
           httpGet:
             scheme: "HTTP"
             path: /health
-            port: {{ .Values.tib.service.port }}
+            port: {{ .Values.tib.containerPort }}
           initialDelaySeconds: 1
           periodSeconds: 10
           timeoutSeconds: 3

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -79,6 +79,24 @@ spec:
             mountPath: /opt/tyk-identity-broker/profiles.json
             subPath: profiles.json
             readOnly: true
+        livenessProbe:
+          httpGet:
+            scheme: "HTTP"
+            path: /health
+            port: {{ .Values.tib.service.port }}
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 3
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            scheme: "HTTP"
+            path: /health
+            port: {{ .Values.tib.service.port }}
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
       volumes:
         - name: tyk-tib-conf-volume
           configMap:

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -10,6 +10,13 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.tib.replicaCount }}
+  minReadySeconds: 10
+  strategy:
+    # indicate which strategy we want for rolling update
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: tib-{{ include "tyk-pro.fullname" . }}
@@ -20,13 +27,6 @@ spec:
         app: tib-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      minReadySeconds: 20
-      strategy:
-        # indicate which strategy we want for rolling update
-        type: RollingUpdate
-        rollingUpdate:
-          maxSurge: 2
-          maxUnavailable: 1
 {{- if .Values.tib.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.tib.nodeSelector | indent 8 }}

--- a/tyk-pro/templates/ingress-dash.yaml
+++ b/tyk-pro/templates/ingress-dash.yaml
@@ -35,6 +35,6 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: dashboard-svc-{{ $fullName }}
-              servicePort: {{ $.Values.dash.service.port }}
+              servicePort: http
   {{- end }}
 {{- end }}

--- a/tyk-pro/templates/service-dash.yaml
+++ b/tyk-pro/templates/service-dash.yaml
@@ -10,8 +10,9 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.dash.service.port }}
-    targetPort: 3000
+    targetPort: {{ .Values.dash.containerPort }}
     protocol: TCP
+    name: http
   type: {{ .Values.dash.service.type }}
   selector:
     app: dashboard-{{ include "tyk-pro.fullname" . }}

--- a/tyk-pro/templates/service-gw.yaml
+++ b/tyk-pro/templates/service-gw.yaml
@@ -17,7 +17,7 @@ spec:
   type: {{ .Values.gateway.service.type }}
   ports:
   - port: {{ .Values.gateway.service.port }}
-    targetPort: 8080
+    targetPort: {{ .Values.gateway.containerPort }}
     protocol: TCP
     name: http
   selector:

--- a/tyk-pro/templates/service-tib.yaml
+++ b/tyk-pro/templates/service-tib.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.tib.service.port }}
-    targetPort: {{ .Values.tib.service.port }}
+    targetPort: {{ .Values.tib.containerPort }}
     protocol: TCP
     name: http
   type: {{ .Values.tib.service.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,7 @@ tib:
   enabled: false
   useSSL: true
   replicaCount: 1
+  containerPort: 3010
   image:
     repository: tykio/tyk-identity-broker
     tag: latest
@@ -69,6 +70,7 @@ dash:
   replicaCount: 1
   hostName: "dashboard.tykbeta.com"
   license: "ADD-LICENSE-HERE"
+  containerPort: 3000
   image:
     repository: tykio/tyk-dashboard
     tag: latest
@@ -124,6 +126,7 @@ gateway:
   hostName: "gateway.tykbeta.com"
   tags: "ingress"
   tls: true
+  containerPort: 8080
   image:
     repository: tykio/tyk-gateway
     tag: latest
@@ -196,8 +199,6 @@ tyk_k8s:
   serviceMesh:
     enabled: false
   watchNamespaces: []
-  service:
-    port: 443
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little

--- a/values.yaml
+++ b/values.yaml
@@ -14,13 +14,13 @@ secrets:
 
 redis:
     shardCount: 128
-    host: redis-redis.redis
+    host: "tyk-redis-master.tyk-ingress.svc.cluster.local"
     port: 6379
     useSSL: false
     pass: ""
 
 mongo:
-    mongoURL: "mongodb://mongodb-mongodb-replicaset.mongodb:27017/tyk-dashboard"
+    mongoURL: "mongodb://root:pass@tyk-mongo-mongodb.tyk-ingress.svc.cluster.local:27017/tyk-dashboard?authSource=admin"
     useSSL: false
 
 tib:
@@ -132,6 +132,18 @@ gateway:
     port: 443
     externalTrafficPolicy: Local
     annotations: {}
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    path: /
+    hosts:
+      - tyk-gw.local
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -179,7 +191,22 @@ tyk_k8s:
     repository: tykio/tyk-k8s
     tag: stable
     pullPolicy: Always
-  org_id: "DUMMY"
-  dash_key: "DUMMY"
+  serviceMesh:
+    enabled: false
+  watchNamespaces: []
   service:
     port: 443
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/values.yaml
+++ b/values.yaml
@@ -121,6 +121,7 @@ portal:
 gateway:
   kind: DaemonSet
   replicaCount: 2
+  hostName: "gateway.tykbeta.com"
   tags: "ingress"
   tls: true
   image:
@@ -187,7 +188,8 @@ pump:
 
 rbac: true 
 tyk_k8s:
-  image: 
+  replicaCount: 1
+  image:
     repository: tykio/tyk-k8s
     tag: stable
     pullPolicy: Always

--- a/values_community_edition.yaml
+++ b/values_community_edition.yaml
@@ -26,6 +26,7 @@ mongo:
 gateway:
   kind: DaemonSet
   replicaCount: 1
+  hostName: "gateway.tykbeta.com"
   tls: true
   redis:
     shardCount: 128

--- a/values_community_edition.yaml
+++ b/values_community_edition.yaml
@@ -28,6 +28,7 @@ gateway:
   replicaCount: 1
   hostName: "gateway.tykbeta.com"
   tls: true
+  containerPort: 8080
   redis:
     shardCount: 128
     host: redis.service
@@ -106,8 +107,6 @@ tyk_k8s:
   serviceMesh:
     enabled: false
   watchNamespaces: []
-  service:
-    port: 443
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little

--- a/values_community_edition.yaml
+++ b/values_community_edition.yaml
@@ -14,13 +14,13 @@ secrets:
 
 redis:
     shardCount: 128
-    host: redis-redis.redis
+    host: "tyk-redis-master.tyk-ingress.svc.cluster.local"
     port: 6379
     useSSL: false
     # pass: ""
 
 mongo:
-  mongoURL: "mongodb://mongodb-mongodb-replicaset.mongodb:27017/tyk-dashboard"
+  mongoURL: "mongodb://root:pass@tyk-mongo-mongodb.tyk-ingress.svc.cluster.local:27017/tyk-dashboard?authSource=admin"
   useSSL: false
 
 gateway:
@@ -43,6 +43,18 @@ gateway:
     port: 443
     externalTrafficPolicy: Local
     annotations: {}
+  ingress:
+    enabled: false
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    path: /
+    hosts:
+      - tyk-gw.local
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -90,7 +102,22 @@ tyk_k8s:
     repository: tykio/tyk-k8s
     tag: headless
     pullPolicy: Always
-  org_id: "DUMMY"
-  dash_key: "DUMMY"
+  serviceMesh:
+    enabled: false
+  watchNamespaces: []
   service:
     port: 443
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/values_hybrid.yaml
+++ b/values_hybrid.yaml
@@ -15,7 +15,7 @@ secrets:
 
 redis:
   shardCount: 128
-  host: redis-master.redis
+  host: "tyk-redis-master.tyk-ingress.svc.cluster.local"
   port: 6379
   useSSL: false
   pass: ""
@@ -41,6 +41,18 @@ gateway:
     port: 443
     externalTrafficPolicy: Local
     annotations: {}
+  ingress:
+    enabled: false
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    path: /
+    hosts:
+      - tyk-gw.local
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -72,5 +84,22 @@ tyk_k8s:
   dash_key: "APIKEY"
   # If using Multi Cloud this URL is *https://admin.cloud.tyk.io* or the URL of Master DC Dashboard in MDCB Setup
   dash_url: "DASHBOARDURL"
+  serviceMesh:
+    enabled: false
+  watchNamespaces: []
   service:
     port: 443
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/values_hybrid.yaml
+++ b/values_hybrid.yaml
@@ -23,8 +23,9 @@ redis:
 gateway:
   kind: DaemonSet
   # Set replicaCount for Deployments
-  #replicaCount: 2
+  replicaCount: 2
   tags: "ingress"
+  hostName: ""
   tls: true
   # For MDCB setups change to connection string for your MDCB instance
   rpc:
@@ -74,6 +75,7 @@ gateway:
 rbac: true
 
 tyk_k8s:
+  replicaCount: 1
   image:
     repository: tykio/tyk-k8s
     tag: stable

--- a/values_hybrid.yaml
+++ b/values_hybrid.yaml
@@ -27,6 +27,7 @@ gateway:
   tags: "ingress"
   hostName: ""
   tls: true
+  containerPort: 8080
   # For MDCB setups change to connection string for your MDCB instance
   rpc:
     connString: "hybrid.cloud.tyk.io:9091"
@@ -89,8 +90,6 @@ tyk_k8s:
   serviceMesh:
     enabled: false
   watchNamespaces: []
-  service:
-    port: 443
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This updates resources all across the charts, which makes them work on k8s 1.16+.

Brings "tyk_k8s.watchNamespaces" array option to watch only specific namespaces in the ingress controller (depends on https://github.com/TykTechnologies/tyk-k8s/pull/30).

Simplifies ingress controller chart installation by not requiring certificate generation unless service mesh injector is required. Clarifies some instructions and readme too a bit.

Fixes RBAC in the ingress controller's cluster role.

Bootstrap script now works with Python 3.x.