### PR TITLE
change command parameter

### DIFF
--- a/tyk-pro/templates/deployment-mdcb.yaml
+++ b/tyk-pro/templates/deployment-mdcb.yaml
@@ -80,7 +80,7 @@ spec:
         {{- end }}
         resources:
         {{ toYaml .Values.mdcb.resources | indent 12 }}
-        command: ["/opt/tyk-sink/tyk-sink", "--conf=/etc/tyk-sink/tyk_sink.conf"]
+        command: ["/opt/tyk-sink/tyk-sink", "--c=/etc/tyk-sink/tyk_sink.conf"]
         workingDir: /opt/tyk-sink
         ports:
         - containerPort: {{ .Values.mdcb.containerPort }}


### PR DESCRIPTION
Pod doesn't start with the '--conf' parameter and logs that it does not know the parameter but instead, it knows '--c'.

Log of the mdcb pod:

```
flag provided but not defined: -conf
Usage of /opt/tyk-sink/tyk-sink:
  -c string
    	Path to the config file (default "./tyk_sink.conf")
  -debug
    	Enable verbose output
```