### PR TITLE
Update hybrid gateway ingress resource and bump hybrid chart version

### DIFF
--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Hybrid Gateway, assumes Redis has already been installed
 name: tyk-hybrid
-version: 0.2.1
+version: 0.2.2

--- a/tyk-hybrid/templates/ingress-gw.yaml
+++ b/tyk-hybrid/templates/ingress-gw.yaml
@@ -1,12 +1,13 @@
 {{- if .Values.gateway.ingress.enabled -}}
-{{- $fullName := include "tyk-hybrid.fullname" . -}}
+{{- $serviceName := include "tyk-hybrid.fullname" . -}}
+{{- $servicePort := .Values.gateway.service.port -}}
 {{- $ingressPath := .Values.gateway.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: gateway-ing-{{ $fullName }}
+  name: gateway-ing-{{ include "tyk-hybrid.fullname" . }}
   labels:
-    app: gateway-ing-{{ $fullName }}
+    app: gateway-ing-{{ include "tyk-hybrid.fullname" . }}
     chart: {{ include "tyk-hybrid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -17,22 +18,16 @@ metadata:
 spec:
 {{- if .Values.gateway.ingress.tls }}
   tls:
-  {{- range .Values.gateway.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{ toYaml .Values.gateway.ingress.tls | nindent 4 }}
   {{- end }}
-{{- end }}
   rules:
   {{- range .Values.gateway.ingress.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ . }}
       http:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: gateway-svc-{{ $fullName }}
-              servicePort: http
+              serviceName: gateway-svc-{{ $serviceName }}
+              servicePort: {{ $servicePort }}
   {{- end }}
 {{- end }}

--- a/tyk-hybrid/templates/ingress-gw.yaml
+++ b/tyk-hybrid/templates/ingress-gw.yaml
@@ -1,13 +1,12 @@
 {{- if .Values.gateway.ingress.enabled -}}
-{{- $serviceName := include "tyk-hybrid.fullname" . -}}
-{{- $servicePort := .Values.gateway.service.port -}}
+{{- $fullName := include "tyk-hybrid.fullname" . -}}
 {{- $ingressPath := .Values.gateway.ingress.path -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: gateway-ing-{{ include "tyk-hybrid.fullname" . }}
+  name: gateway-ing-{{ $fullName }}
   labels:
-    app: gateway-ing-{{ include "tyk-hybrid.fullname" . }}
+    app: gateway-ing-{{ $fullName }}
     chart: {{ include "tyk-hybrid.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -18,16 +17,22 @@ metadata:
 spec:
 {{- if .Values.gateway.ingress.tls }}
   tls:
-  {{ toYaml .Values.gateway.ingress.tls | nindent 4 }}
+  {{- range .Values.gateway.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
   {{- end }}
+{{- end }}
   rules:
   {{- range .Values.gateway.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote}}
       http:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: gateway-svc-{{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              serviceName: gateway-svc-{{ $fullName }}
+              servicePort: http
   {{- end }}
 {{- end }}

--- a/tyk-hybrid/templates/ingress-gw.yaml
+++ b/tyk-hybrid/templates/ingress-gw.yaml
@@ -27,7 +27,7 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.gateway.ingress.hosts }}
-    - host: {{ . | quote}}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}

--- a/tyk-hybrid/templates/service-gw.yaml
+++ b/tyk-hybrid/templates/service-gw.yaml
@@ -19,6 +19,7 @@ spec:
   - port: {{ .Values.gateway.service.port }}
     targetPort: {{ .Values.gateway.containerPort }}
     protocol: TCP
+    name: http
   selector:
     app: gateway-{{ include "tyk-hybrid.fullname" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Update Hybrid gateway ingress resource to allow different gateway service ports being used. Atm we're allowing only http, which is causing issue, if you want to use https for example, hence the PR to extend this functionality. Also bump hybrid chart version.