### PR TITLE
update deprecated apiVersions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you are running an older chart that does not have this value, then you can di
 To enable the ingress controller, simply add the ingress class defintiion to your ingress annotations:
 
 ```yml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cafe-ingress
@@ -130,7 +130,7 @@ By default Tyk will create an open API (no security enabled), however you can se
 Here's an example:
 
 ```yml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cafe-ingress
@@ -202,7 +202,7 @@ spec:
             - key: tyk_k8s.yaml
               path: tyk-k8s.yaml
 
-### Custom templates:        
+### Custom templates:
         - name: tyk-k8s-templates
           configMap:
             name: token-auth
@@ -245,7 +245,7 @@ kubectl create configmap token-auth --from-file=token-auth.json --namespace {nam
 Once these template configMaps have been added, and your tyk-k8s service is running, you can set up your service definitions very easily by adding a single annotation:
 
 ```yml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cafe-ingress
@@ -285,7 +285,7 @@ The service mesh injector will create two services:
 Setting up a service to use the injector is very simple, simply add the inject annotation to your Deployment:
 
 ```yml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sleep

--- a/tyk-hybrid/templates/ingress-gw.yaml
+++ b/tyk-hybrid/templates/ingress-gw.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.gateway.ingress.enabled -}}
 {{- $fullName := include "tyk-hybrid.fullname" . -}}
 {{- $ingressPath := .Values.gateway.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: gateway-ing-{{ $fullName }}

--- a/tyk-k8s/tests/ingress/cafe.yaml
+++ b/tyk-k8s/tests/ingress/cafe.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coffee
@@ -13,10 +13,10 @@ spec:
         app: coffee
     spec:
       containers:
-      - name: coffee
-        image: nginxdemos/hello:plain-text
-        ports:
-        - containerPort: 80
+        - name: coffee
+          image: nginxdemos/hello:plain-text
+          ports:
+            - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
@@ -24,14 +24,14 @@ metadata:
   name: coffee-svc
 spec:
   ports:
-  - port: 80
-    targetPort: 80
-    protocol: TCP
-    name: http
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
   selector:
     app: coffee
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tea
@@ -39,17 +39,17 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app: tea 
+      app: tea
   template:
     metadata:
       labels:
-        app: tea 
+        app: tea
     spec:
       containers:
-      - name: tea 
-        image: nginxdemos/hello:plain-text
-        ports:
-        - containerPort: 80
+        - name: tea
+          image: nginxdemos/hello:plain-text
+          ports:
+            - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
@@ -58,9 +58,9 @@ metadata:
   labels:
 spec:
   ports:
-  - port: 80
-    targetPort: 80
-    protocol: TCP
-    name: http
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
   selector:
     app: tea

--- a/tyk-k8s/tests/ingress/ingress.yaml
+++ b/tyk-k8s/tests/ingress/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cafe-ingress
@@ -6,14 +6,14 @@ metadata:
     kubernetes.io/ingress.class: tyk
 spec:
   rules:
-  - host: cafe.example.com
-    http:
-      paths:
-      - path: /tea
-        backend:
-          serviceName: tea-svc
-          servicePort: 80
-      - path: /coffee
-        backend:
-          serviceName: coffee-svc
-          servicePort: 80
+    - host: cafe.example.com
+      http:
+        paths:
+          - path: /tea
+            backend:
+              serviceName: tea-svc
+              servicePort: 80
+          - path: /coffee
+            backend:
+              serviceName: coffee-svc
+              servicePort: 80

--- a/tyk-pro/templates/ingress-dash.yaml
+++ b/tyk-pro/templates/ingress-dash.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.dash.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
 {{- $ingressPath := .Values.dash.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: dash-ing-{{ $fullName }}

--- a/tyk-pro/templates/ingress-gw.yaml
+++ b/tyk-pro/templates/ingress-gw.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.gateway.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
 {{- $ingressPath := .Values.gateway.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: gateway-ing-{{ $fullName }}

--- a/tyk-pro/templates/ingress-portal.yaml
+++ b/tyk-pro/templates/ingress-portal.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.portal.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
 {{- $ingressPath := .Values.portal.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: portal-ing-{{ $fullName }}

--- a/tyk-pro/templates/ingress-tib.yaml
+++ b/tyk-pro/templates/ingress-tib.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.tib.enabled .Values.tib.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
 {{- $ingressPath := .Values.tib.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: tib-ing-{{ $fullName }}


### PR DESCRIPTION
This PR updates `extensions/v1beta1` to use the proper non-deprecated/removed apiVersions for deployments and ingresses.

It also contains some formatting changes that make all the yaml formatted the same across the different files that I touched.