### PR TITLE
Run containers as non-root by default

### DIFF
--- a/tyk-headless/Chart.yaml
+++ b/tyk-headless/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Gateway, assumes that MongoDB and Redis have already been installed
 name: tyk-headless
-version: 0.4.0
+version: 0.4.1

--- a/tyk-headless/configs/tyk_mgmt.conf
+++ b/tyk-headless/configs/tyk_mgmt.conf
@@ -44,7 +44,7 @@
     "allow_master_keys": false,
     "policies": {
         "policy_source": "file",
-        "policy_record_name": "/opt/tyk-gateway/policies/policies.json"
+        "policy_record_name": "/mnt/tyk-gateway/policies/policies.json"
     },
     "hash_keys": true,
     "hash_key_function": "murmur128",

--- a/tyk-headless/configs/tyk_mgmt.conf
+++ b/tyk-headless/configs/tyk_mgmt.conf
@@ -5,14 +5,14 @@
     "node_secret": "$sharedsecret",
     "template_path": "/opt/tyk-gateway/templates",
     "tyk_js_path": "/opt/tyk-gateway/js/tyk.js",
-    "middleware_path": "/opt/tyk-gateway/middleware",
+    "middleware_path": "/mnt/tyk-gateway/middleware",
     "use_db_app_configs": false,
     "db_app_conf_options": {
         "connection_string": "",
         "node_is_segmented": false,
         "tags": []
     },
-    "app_path": "/opt/tyk-gateway/apps/",
+    "app_path": "/mnt/tyk-gateway/apps",
     "storage": {
         "type": "redis",
         "enable_cluster": false,
@@ -44,7 +44,7 @@
     "allow_master_keys": false,
     "policies": {
         "policy_source": "file",
-        "policy_record_name": "/opt/tyk-gateway/policies/policies.json"    
+        "policy_record_name": "/opt/tyk-gateway/policies/policies.json"
     },
     "hash_keys": true,
     "hash_key_function": "murmur128",
@@ -70,5 +70,6 @@
     "global_session_lifetime": 100,
     "force_global_session_lifetime": false,
     "max_idle_connections_per_host": 500,
-    "enable_custom_domains": true
+    "enable_custom_domains": true,
+    "pid_file_location": "/mnt/tyk-gateway/tyk.pid"
 }

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -86,7 +86,13 @@ spec:
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         securityContext:
-            runAsNonRoot: true
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
           - name: TYK_GW_LISTENPORT
             value: "{{ .Values.gateway.containerPort }}"
@@ -121,6 +127,8 @@ spec:
             mountPath: /etc/tyk-gateway
           - name: {{ .Release.Name }}-default-cert
             mountPath: /etc/certs
+          - name: tyk-scratch
+            mountPath: /mnt/tyk-gateway
         livenessProbe:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
@@ -155,6 +163,9 @@ spec:
             mountPath: /etc/tyk-k8s
         resources:
 {{ toYaml .Values.tyk_k8s.resources | indent 12 }}
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       volumes:
         - name: tyk-k8s-conf
           configMap:
@@ -162,6 +173,8 @@ spec:
             items:
               - key: tyk_k8s.yaml
                 path: tyk-k8s.yaml
+        - name: tyk-scratch
+          emptyDir: {}
         - name: tyk-mgmt-gateway-conf
           configMap:
             name: mgmt-gateway-conf-{{ include "tyk-headless.fullname" . }}

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -85,6 +85,8 @@ spec:
       - name: gateway-{{ .Chart.Name }}
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+        securityContext:
+            runAsNonRoot: true
         env:
           - name: TYK_GW_LISTENPORT
             value: "{{ .Values.gateway.containerPort }}"

--- a/tyk-headless/templates/deployment-pmp.yaml
+++ b/tyk-headless/templates/deployment-pmp.yaml
@@ -36,6 +36,14 @@ spec:
         image: "{{ .Values.pump.image.repository }}:{{ .Values.pump.image.tag }}"
         imagePullPolicy: {{ .Values.pump.image.pullPolicy }}
         workingDir: "/opt/tyk-pump"
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"
@@ -65,6 +73,9 @@ spec:
             mountPath: /etc/tyk-pump
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       volumes:
         - name: tyk-pump-conf
           configMap:

--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Hybrid Gateway, assumes Redis has already been installed
 name: tyk-hybrid
-version: 0.2.1
+version: 0.2.2

--- a/tyk-hybrid/configs/tyk_hybrid.conf
+++ b/tyk-hybrid/configs/tyk_hybrid.conf
@@ -2,9 +2,9 @@
     "listen_port": 8080,
     "template_path": "/opt/tyk-gateway/templates",
     "tyk_js_path": "/opt/tyk-gateway/js/tyk.js",
-    "middleware_path": "/opt/tyk-gateway/middleware",
+    "middleware_path": "/mnt/tyk-gateway/middleware",
     "use_db_app_configs": false,
-    "app_path": "/opt/tyk-gateway/apps/",
+    "app_path": "/mnt/tyk-gateway/apps",
     "storage": {
         "type": "redis",
         "enable_cluster": false,
@@ -80,5 +80,6 @@
     "global_session_lifetime": 100,
     "force_global_session_lifetime": false,
     "max_idle_connections_per_host": 500,
-    "enable_custom_domains": true
+    "enable_custom_domains": true,
+    "pid_file_location": "/mnt/tyk-gateway/tyk.pid"
 }

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -51,7 +51,13 @@ spec:
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         securityContext:
-            runAsNonRoot: true
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
           - name: TYK_GW_LISTENPORT
             value: "{{ .Values.gateway.containerPort }}"
@@ -98,6 +104,8 @@ spec:
             mountPath: /etc/tyk-gateway
           - name: {{ .Release.Name }}-default-cert
             mountPath: /etc/certs
+          - name: tyk-scratch
+            mountPath: /mnt/tyk-gateway
         livenessProbe:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
@@ -116,6 +124,9 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       volumes:
         - name: hybrid-gateway-conf
           configMap:
@@ -123,6 +134,8 @@ spec:
             items:
               - key: tyk_hybrid.conf
                 path: tyk.conf
+        - name: tyk-scratch
+          emptyDir: {}
         - name: {{ .Release.Name }}-default-cert
           secret:
             secretName: {{ .Release.Name }}-default-cert

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -50,6 +50,8 @@ spec:
       - name: gateway-{{ .Chart.Name }}
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+        securityContext:
+            runAsNonRoot: true
         env:
           - name: TYK_GW_LISTENPORT
             value: "{{ .Values.gateway.containerPort }}"

--- a/tyk-pro/Chart.yaml
+++ b/tyk-pro/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Dashboard, assumes that MongoDB and Redis have already been installed
 name: tyk-pro
-version: 0.5.0
+version: 0.5.1

--- a/tyk-pro/configs/tyk_mgmt.conf
+++ b/tyk-pro/configs/tyk_mgmt.conf
@@ -4,14 +4,14 @@
     "node_secret": "$sharedsecret",
     "template_path": "/opt/tyk-gateway/templates",
     "tyk_js_path": "/opt/tyk-gateway/js/tyk.js",
-    "middleware_path": "/opt/tyk-gateway/middleware",
+    "middleware_path": "/mnt/tyk-gateway/middleware",
     "use_db_app_configs": true,
     "db_app_conf_options": {
         "connection_string": "http://tyk-dashboard.$namespace:3000",
         "node_is_segmented": true,
         "tags": []
     },
-    "app_path": "/opt/tyk-gateway/apps/",
+    "app_path": "/mnt/tyk-gateway/apps",
     "storage": {
         "type": "redis",
         "enable_cluster": false,
@@ -70,5 +70,6 @@
     "global_session_lifetime": 100,
     "force_global_session_lifetime": false,
     "max_idle_connections_per_host": 500,
-    "enable_custom_domains": true
+    "enable_custom_domains": true,
+    "pid_file_location": "/mnt/tyk-gateway/tyk.pid"
 }

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -43,12 +43,13 @@ spec:
         imagePullPolicy: {{ .Values.dash.image.pullPolicy }}
         name: dashboard-{{ .Chart.Name }}
         securityContext:
-            allowPrivilegeEscalation: false
-            privileged: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - all
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
           - name: TYK_DB_LISTENPORT
             value: "{{ .Values.dash.containerPort }}"
@@ -115,6 +116,9 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       volumes:
         - name: tyk-dashboard-conf
           configMap:

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -42,6 +42,13 @@ spec:
       - image: "{{ .Values.dash.image.repository }}:{{ .Values.dash.image.tag }}"
         imagePullPolicy: {{ .Values.dash.image.pullPolicy }}
         name: dashboard-{{ .Chart.Name }}
+        securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
         env:
           - name: TYK_DB_LISTENPORT
             value: "{{ .Values.dash.containerPort }}"

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -50,6 +50,8 @@ spec:
       - name: gateway-{{ .Chart.Name }}
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+        securityContext:
+            runAsNonRoot: true
         env:
           - name: TYK_GW_LISTENPORT
             value: "{{ .Values.gateway.containerPort }}"

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -51,7 +51,13 @@ spec:
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         securityContext:
-            runAsNonRoot: true
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
           - name: TYK_GW_LISTENPORT
             value: "{{ .Values.gateway.containerPort }}"
@@ -92,6 +98,8 @@ spec:
         volumeMounts:
           - name: tyk-mgmt-gateway-conf
             mountPath: /etc/tyk-gateway
+          - name: tyk-scratch
+            mountPath: /mnt/tyk-gateway
           - name: {{ .Release.Name }}-default-cert
             mountPath: /etc/certs
         livenessProbe:
@@ -112,6 +120,9 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       volumes:
         - name: tyk-mgmt-gateway-conf
           configMap:
@@ -119,6 +130,8 @@ spec:
             items:
               - key: tyk_mgmt.conf
                 path: tyk.conf
+        - name: tyk-scratch
+          emptyDir: {}
         - name: {{ .Release.Name }}-default-cert
           secret:
             secretName: {{ .Release.Name }}-default-cert

--- a/tyk-pro/templates/deployment-mdcb.yaml
+++ b/tyk-pro/templates/deployment-mdcb.yaml
@@ -48,13 +48,13 @@ spec:
         imagePullPolicy: {{ .Values.mdcb.image.pullPolicy }}
         name: dashboard-{{ .Chart.Name }}
         securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            privileged: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - all
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
           - name: TYK_MDCB_SERVEROPTIONS_USESSL
             value: "{{ .Values.mdcb.useSSL }}"
@@ -113,6 +113,9 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       volumes:
         - name: tyk-mdcb-conf
           configMap:

--- a/tyk-pro/templates/deployment-mdcb.yaml
+++ b/tyk-pro/templates/deployment-mdcb.yaml
@@ -47,6 +47,14 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.mdcb.image.pullPolicy }}
         name: dashboard-{{ .Chart.Name }}
+        securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
         env:
           - name: TYK_MDCB_SERVEROPTIONS_USESSL
             value: "{{ .Values.mdcb.useSSL }}"

--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -43,13 +43,13 @@ spec:
         imagePullPolicy: {{ .Values.pump.image.pullPolicy }}
         workingDir: "/opt/tyk-pump"
         securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            privileged: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - all
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"
@@ -79,6 +79,9 @@ spec:
             mountPath: /etc/tyk-pump
         resources:
 {{ toYaml .Values.pump.resources | indent 12 }}
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       volumes:
         - name: tyk-pump-conf
           configMap:

--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -42,6 +42,14 @@ spec:
         image: "{{ .Values.pump.image.repository }}:{{ .Values.pump.image.tag }}"
         imagePullPolicy: {{ .Values.pump.image.pullPolicy }}
         workingDir: "/opt/tyk-pump"
+        securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
         env:
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -43,6 +43,14 @@ spec:
       - image: "{{ .Values.tib.image.repository }}:{{ .Values.tib.image.tag }}"
         imagePullPolicy: {{ .Values.tib.image.pullPolicy }}
         name: tib-{{ .Chart.Name }}
+        securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
         env:
           - name: TYK_IB_PORT
             value: "{{ .Values.tib.containerPort }}"

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -44,13 +44,13 @@ spec:
         imagePullPolicy: {{ .Values.tib.image.pullPolicy }}
         name: tib-{{ .Chart.Name }}
         securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            privileged: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - all
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
         env:
           - name: TYK_IB_PORT
             value: "{{ .Values.tib.containerPort }}"
@@ -107,6 +107,9 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       volumes:
         - name: tyk-tib-conf-volume
           configMap:


### PR DESCRIPTION
Changed the templates to run all Tyk containers as non-root user by default.
Also keeping an option to change the user for the gateway since there might be a use case where this would be needed.
Bumped chart version.