### PR TITLE
Istio Ingress Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,7 @@ If you are running an older chart that does not have this value, then you can di
 NB: tyk-k8s has been deprecated. For reference, old documentation may be found here: [Tyk K8s](https://github.com/TykTechnologies/tyk-k8s)
 
 For further detail on how to configure Tyk as an Ingress Gateway, or how to manage APIs using the Kubernetes API, please refer to our [Tyk Operator documentation](https://github.com/TykTechnologies/tyk-operator/).
+
+## Istio Service Mesh Ingress gateway
+
+To use Tyks gateways as the ingress to your Istio Service Mesh simply change `enableIstioIngress: true` in the values.yaml. Ensure you are using an Istio manifest which disables the default Istio Ingress gateway.

--- a/samples/httpbin.yaml
+++ b/samples/httpbin.yaml
@@ -35,23 +35,23 @@ spec:
         name: httpbin
         ports:
         - containerPort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: httpbin-ingress
-  annotations:
-    kubernetes.io/ingress.class: tyk
-spec:
-  rules:
-  - host: www.tyk-test.com
-    http:
-      paths:
-      - path: /httpbin
-        backend:
-          serviceName: httpbin
-          servicePort: 80
-      - path: /httpbin2
-        backend:
-          serviceName: httpbin
-          servicePort: 8000
+# ---
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   name: httpbin-ingress
+#   annotations:
+#     kubernetes.io/ingress.class: tyk
+# spec:
+#   rules:
+#   - host: www.tyk-test.com
+#     http:
+#       paths:
+#       - path: /httpbin
+#         backend:
+#           serviceName: httpbin
+#           servicePort: 80
+#       - path: /httpbin2
+#         backend:
+#           serviceName: httpbin
+#           servicePort: 8000

--- a/samples/httpbin.yaml
+++ b/samples/httpbin.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+spec:
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 80
+  selector:
+    app: httpbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      containers:
+      - image: docker.io/kennethreitz/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: httpbin-ingress
+  annotations:
+    kubernetes.io/ingress.class: tyk
+spec:
+  rules:
+  - host: www.tyk-test.com
+    http:
+      paths:
+      - path: /httpbin
+        backend:
+          serviceName: httpbin
+          servicePort: 80
+      - path: /httpbin2
+        backend:
+          serviceName: httpbin
+          servicePort: 8000

--- a/samples/istio/bookinfo.yaml
+++ b/samples/istio/bookinfo.yaml
@@ -1,0 +1,343 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# This file defines the services, service accounts, and deployments for the Bookinfo sample.
+#
+# To apply all 4 Bookinfo services, their corresponding service accounts, and deployments:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+#
+# Alternatively, you can deploy any resource separately:
+#
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l service=reviews # reviews Service
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l account=reviews # reviews ServiceAccount
+#   kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml -l app=reviews,version=v3 # reviews-v3 Deployment
+##################################################################################################
+
+##################################################################################################
+# Details service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: details
+  labels:
+    app: details
+    service: details
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: details
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-details
+  labels:
+    account: details
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: details-v1
+  labels:
+    app: details
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: details
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: details
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-details
+      containers:
+      - name: details
+        image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
+---
+##################################################################################################
+# Ratings service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  labels:
+    app: ratings
+    service: ratings
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: ratings
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-ratings
+  labels:
+    account: ratings
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratings-v1
+  labels:
+    app: ratings
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: ratings
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-ratings
+      containers:
+      - name: ratings
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
+---
+##################################################################################################
+# Reviews service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-reviews
+  labels:
+    account: reviews
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v1
+  labels:
+    app: reviews
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.16.2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+        securityContext:
+          runAsUser: 1000
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v2
+  labels:
+    app: reviews
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v2
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+        securityContext:
+          runAsUser: 1000
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reviews-v3
+  labels:
+    app: reviews
+    version: v3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reviews
+      version: v3
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v3
+    spec:
+      serviceAccountName: bookinfo-reviews
+      containers:
+      - name: reviews
+        image: docker.io/istio/examples-bookinfo-reviews-v3:1.16.2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: LOG_DIR
+          value: "/tmp/logs"
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: wlp-output
+          mountPath: /opt/ibm/wlp/output
+        securityContext:
+          runAsUser: 1000
+      volumes:
+      - name: wlp-output
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+---
+##################################################################################################
+# Productpage services
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage
+  labels:
+    app: productpage
+    service: productpage
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: productpage
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookinfo-productpage
+  labels:
+    account: productpage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productpage-v1
+  labels:
+    app: productpage
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: productpage
+        version: v1
+    spec:
+      serviceAccountName: bookinfo-productpage
+      containers:
+      - name: productpage
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        securityContext:
+          runAsUser: 1000
+      volumes:
+      - name: tmp
+        emptyDir: {}
+---

--- a/tyk-pro/Chart.yaml
+++ b/tyk-pro/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Dashboard, assumes that MongoDB and Redis have already been installed
 name: tyk-pro
-version: 0.6.0
+version: 0.7.0

--- a/tyk-pro/configs/tyk_mgmt.conf
+++ b/tyk-pro/configs/tyk_mgmt.conf
@@ -44,7 +44,9 @@
     "policies": {
         "policy_source": "service",
         "policy_connection_string": "http://tyk-dashboard.$namespace:3000",
-        "policy_record_name": "tyk_policies"
+        "policy_record_name": "tyk_policies",
+        "allow_explicit_policy_id": true
+
     },
     "hash_keys": true,
     "hash_key_function": "murmur128",

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -15,6 +15,9 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
     spec:
       serviceAccountName: k8s-bootstrap-role
       containers:

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dashboard-{{ include "tyk-pro.fullname" . }}

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -29,7 +29,6 @@ spec:
       annotations:
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.dash.containerPort }}"
         traffic.sidecar.istio.io/includeInboundPorts: ""
-        sidecar.istio.io/rewriteAppHTTPProbers: "false"
       {{- end }}
     spec:
 {{- if .Values.dash.nodeSelector }}

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -25,6 +25,12 @@ spec:
       labels:
         app: dashboard-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.enableIstioIngress }}
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.dash.containerPort }}"
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      {{- end }}
     spec:
 {{- if .Values.dash.nodeSelector }}
       nodeSelector:

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -1,4 +1,4 @@
- apiVersion: apps/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dashboard-{{ include "tyk-pro.fullname" . }}

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -36,7 +36,6 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{ .Values.dash.containerPort }}"
         traffic.sidecar.istio.io/includeOutboundPorts: ""
-        sidecar.istio.io/rewriteAppHTTPProbers: "false"
       {{- end }}
       labels:
         app: gateway-{{ include "tyk-pro.fullname" . }}

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -30,6 +30,14 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- if .Values.enableIstioIngress }}
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.gateway.containerPort}}"
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+        traffic.sidecar.istio.io/excludeOutboundPorts: "{{ .Values.dash.containerPort }}"
+        traffic.sidecar.istio.io/includeOutboundPorts: ""
+        sidecar.istio.io/rewriteAppHTTPProbers: "false"
+      {{- end }}
       labels:
         app: gateway-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,11 @@ fullnameOverride: ""
 # Only set this to false if you are not planning on using the sidecar injector
 enableSharding: true
 
+# Set to true to use Tyk as the Ingress gateway to an Istio Service Mesh
+# We apply some exceptions to the Istio IPTables so inbound calls to the 
+# Gateway and Dashboard are exposed to the outside world - see the deployment templates for implementation
+enableIstioIngress: false
+
 secrets:
   APISecret: "CHANGEME"
   AdminSecret: "12345"


### PR DESCRIPTION
Tyk can be situated at the edge of a service mesh as the ingress gateway.

These changes make it easy to use our helm charts for this purpose.

All that needs to be done to test is:

Install Istio on a cluster.

To use Tyks gateways as the ingress to your Istio Service Mesh simply change `enableIstioIngress: true` in the values.yaml. Ensure you are using an Istio manifest which disables the default Istio Ingress gateway.

There will be a docs guide shortly that goes through the whole process based on these changes and also includes using the operator.

Also have added some sample applications to reference from docs and guides.

Also change the gateway config so we are able to use tyk sync and the operator by default with the gateway.

