### PR TITLE
Hybrid improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ To install, *first modify `values_hybrid.yaml` file as follows:*
 > If you are using hybrid gateway with the Tyk Classic Cloud use the rpc settings block commented out in the values yaml
 
 
-
 ## Installing TIB
 
 TIB is not necessary to install for Pro installations and it's functionality is included in the Tyk Dashboard API Manager.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To install, *first modify `values_hybrid.yaml` file as follows:*
 > If you are using hybrid gateway with the Tyk Classic Cloud use the rpc settings block commented out in the values yaml
 
 
+
 ## Installing TIB
 
 TIB is not necessary to install for Pro installations and it's functionality is included in the Tyk Dashboard API Manager.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ To install, *first modify the `values.yaml` file to add your license*:
 
 Follow the instructions in the Notes that follow the installation to find your Tyk login credentials.
 
+## Install Tyk Hybrid Gateways (This can be used either for Hybrid Gateways connected to Tyk Cloud or MDCB Hybrid Gateways)
+
+To install, *first modify `values_hybrid.yaml` file as follows:*
+1. Add your dashboard users organisation ID in `gateway.rpc.orgID` value
+2. Add your dashboard users API key in `gateway.rpc.apiKey` value 
+3. Add your connection string to allow the Hybrid gateway to connect to your control plane in `gateway.rpc.connString`. On the Tyk Cloud Console find this value in the endpoints panel for your control plane deployment.
+
+	`helm install tyk-hybrid -f ./values_hybrid.yaml ./tyk-hybrid -n tyk`
+
+> If you are using hybrid gateway with the Tyk Classic Cloud use the rpc settings block commented out in the values yaml
+
+
 ## Installing TIB
 
 TIB is not necessary to install for Pro installations and it's functionality is included in the Tyk Dashboard API Manager.
@@ -69,20 +81,7 @@ This enables multicluster, multi Data-Centre API management from a single Dashbo
 
 The Tyk owned MDCB registry is private and requires adding users to our organisation which you then define as a secret when pulling the MDCB image. Please contact your account manager to arrange this.
 
-## Install Tyk Hybrid Gateways (This can be used either for Hybrid Gateways connected to Tyk Cloud or MDCB Hybrid Gateways)
 
-To install, first modify `values_hybrid.yaml` file as follows:
-1. Add your RPC key in `tyk_k8s.org_id` value
-2. Add your API key in `tyk_k8s.dash_key` value (could be the API key of any dashboard user but better to have a dedicated one)
-3. Add your dashboard URL in `tyk_k8s.dash_url` value. If it's a Tyk SaaS account the value `https://admin.cloud.tyk.io` is already set for you.
-
-	helm install tyk-hybrid -f ./values_hybrid.yaml ./tyk-hybrid -n tyk
-
-To check all the helm installations run:
-	`kubectl get secret --all-namespaces -l "owner=helm"`
-
-To uninstall run:
-	`helm uninstall tyk-hybrid -n=tyk`
 
 ## Caveat: Tyk license and the number of gateway nodes
 

--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Hybrid Gateway, assumes Redis has already been installed
 name: tyk-hybrid
-version: 0.3.0
+version: 0.4.0

--- a/tyk-hybrid/configs/tyk_hybrid.conf
+++ b/tyk-hybrid/configs/tyk_hybrid.conf
@@ -38,11 +38,11 @@
         "use_rpc": true,
         "rpc_key": "",
         "api_key": "",
-        "connection_string": "hybrid.cloud.tyk.io:9091",
+        "connection_string": "",
         "use_ssl": true,
         "rpc_pool_size": 20,
         "enable_rpc_cache": true,
-        "bind_to_slugs": true
+        "bind_to_slugs": false
     },
     "health_check": {
         "enable_health_checks": false,

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -78,17 +78,19 @@ spec:
           - name: TYK_GW_HTTPSERVEROPTIONS_USESSL
             value: "{{ .Values.gateway.tls }}"
           - name: TYK_GW_SLAVEOPTIONS_RPCKEY
-            value: "{{.Values.tyk_k8s.org_id }}"
+            value: "{{ default .Values.tyk_k8s.org_id .Values.rpc.rpcKey }}"
           - name: TYK_GW_SLAVEOPTIONS_APIKEY
-            value: "{{ .Values.tyk_k8s.dash_key }}"
+            value: "{{ default .Values.tyk_k8s.dash_key .Values.rpc.apiKey }}"
           - name: TYK_GW_SECRET
             value: "{{ .Values.secrets.APISecret }}"
           - name: TYK_GW_SLAVEOPTIONS_CONNECTIONSTRING
             value: "{{ .Values.gateway.rpc.connString}}"
           - name: TYK_GW_SLAVEOPTIONS_USESSL
             value: "{{ .Values.gateway.rpc.useSSL}}"
-          - name: TYK_GW_SLAVEOPTIONS_BINDTOSLUGS
-            value: "{{ .Values.gateway.rpc.bindToSlugs }}"
+          - name: TYK_GW_SLAVEOPTIONS_BINDTOSLUGSINSTEADOFLISTENPATHS
+            value: "{{ default "false" .Values.gateway.rpc.bindToSlugs }}"
+          - name: TYK_GW_SLAVEOPTIONS_SSLINSECURESKIPVERIFY
+            value: "{{ .Values.gateway.rpc.sslInsecureSkipVerify }}"  
           - name: TYK_GW_DBAPPCONFOPTIONS_NODEISSEGMENTED
             value: "{{ .Values.enableSharding }}"
           - name: TYK_GW_DBAPPCONFOPTIONS_TAGS

--- a/values_hybrid.yaml
+++ b/values_hybrid.yaml
@@ -5,13 +5,11 @@
 nameOverride: ""
 fullnameOverride: ""
 
-# Only set this to false if you are not planning on using the sidecar injector
-enableSharding: true
+enableSharding: false
 hybrid: true
 
 secrets:
   APISecret: "CHANGEME"
-  AdminSecret: "12345"
 
 redis:
     shardCount: 128
@@ -22,27 +20,42 @@ redis:
       - "redis.tyk.svc.cluster.local:6379"
     useSSL: false
     #If you're using Bitnami Redis chart please input your password in the field below
+    #pass: ""
 
 gateway:
   kind: DaemonSet
   # Set replicaCount for Deployments
   replicaCount: 2
-  tags: "ingress"
+  # if enableSharding set to true then you must define a tag to load APIs to these gateways i.e. "ingress"
+  tags: ""
   hostName: ""
   tls: true
   containerPort: 8080
-  # For MDCB setups change to connection string for your MDCB instance
+  # For on premise MDCB setups simply change the connection string to point to your MDCB instance
   rpc:
-    connString: "hybrid.cloud.tyk.io:9091"
+    # On the Tyk Cloud Console find this value in the endpoints for your control plane deployment
+    connString: ""
     useSSL: true
-    # for hybrid, bindToSlugs: true, for MDCB, bindToSlugs: false
-    bindToSlugs: true
+    sslInsecureSkipVerify: true
+    # orgID of your dashboard user
+    rpcKey: ""
+    # API key of your dashboard user
+    apiKey: ""
+    #
+    # For a classic cloud hybrid gateway use these settings:
+    #
+    # connString: "hybrid.cloud.tyk.io:9091"
+    # useSSL: true
+    # bindToSlugs: true
+    # sslInsecureSkipVerify: false
+    # rpcKey: ""
+    # apiKey: ""
   image:
     repository: tykio/tyk-gateway
     tag: v3.1.2
     pullPolicy: Always
   service:
-    type: LoadBalancer
+    type: NodePort
     port: 443
     externalTrafficPolicy: Local
     annotations: {}


### PR DESCRIPTION
Some improvements to docs and useability aimed at improving the get started journey for Tyk Cloud users.

 - Move the RPC key and API key fields to the gateway RPC section
 - insecure skip verify is default
 - remove bindtoslugs
 - move helm install command up and style like the others
 - Change lb service to nodeport to match other charts
 - add some helpful comments and an example config so that classic cloud users can keep using these charts