### PR TITLE
OSS Deployment improvements

### DIFF
--- a/tyk-headless/Chart.yaml
+++ b/tyk-headless/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Gateway, assumes that MongoDB and Redis have already been installed
 name: tyk-headless
-version: 0.5.0
+version: 0.6.0
 

--- a/tyk-headless/configs/tyk_mgmt.conf
+++ b/tyk-headless/configs/tyk_mgmt.conf
@@ -24,7 +24,7 @@
         "database": 0,
         "optimisation_max_idle": 1000
     },
-    "enable_analytics": true,
+    "enable_analytics": false,
     "analytics_config": {
         "type": "mongo",
         "csv_dir": "/tmp",

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -81,6 +81,10 @@ spec:
             value: "{{ .Values.secrets.APISecret }}"
           - name: TYK_GW_HTTPSERVEROPTIONS_USESSL
             value: "{{ .Values.gateway.tls }}"
+            {{- if .Values.pump.enabled }}
+          - name: TYK_GW_ENABLEANALYTICS
+            value: {{ "true" }}
+            {{- end }}
         {{- if .Values.gateway.extraEnvs }}
         {{- range $env := .Values.gateway.extraEnvs }}
           - name: {{ $env.name }}

--- a/values_community_edition.yaml
+++ b/values_community_edition.yaml
@@ -6,7 +6,7 @@ nameOverride: ""
 fullnameOverride: "tyk-headless"
 
 # Only set this to false if you are not planning on using the sidecar injector
-enableSharding: true
+enableSharding: false
 
 secrets:
   APISecret: "CHANGEME"
@@ -14,20 +14,20 @@ secrets:
 
 redis:
     shardCount: 128
-    #If you're using Bitnami Redis chart please input the correct host to your instalaltion in the field below
-    #addrs:
-    #- "tyk-redis-master.tyk.svc.cluster.local:6379"
     addrs:
       - "redis.tyk.svc.cluster.local:6379"
     useSSL: false
+    #If you're using Bitnami Redis chart please input the correct host to your installation in the field below
+    #addrs:
+      #- "tyk-redis-master.tyk.svc.cluster.local:6379"
     #If you're using Bitnami Redis chart please input your password in the field below
-    #pass: ""
+      #pass: ""
 
-mongo:
-    mongoURL: "mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics"
-    #If you're using Bitnami MongoDB chart please input your password below
-    #mongoURL: "mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin"
-    useSSL: false
+#mongo:
+#    mongoURL: "mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics"
+#    #If you're using Bitnami MongoDB chart please input your password below
+#    #mongoURL: "mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin"
+#    useSSL: false
 
 gateway:
   kind: DaemonSet
@@ -35,13 +35,13 @@ gateway:
   hostName: "gateway.tykbeta.com"
   tls: true
   containerPort: 8080
-  tags: "ingress"
+  tags: ""
   image:
     repository: tykio/tyk-gateway
     tag: v3.1.2
     pullPolicy: IfNotPresent
   service:
-    type: LoadBalancer
+    type: NodePort
     port: 443
     externalTrafficPolicy: Local
     annotations: {}
@@ -75,7 +75,10 @@ gateway:
   affinity: {}
   extraEnvs: []
 
+# If pump is enabled the Gateway will create and collect analytics data to send to a data store of your choice
+# These can be set up in the pump config. The possible pump configs can be found here: https://github.com/TykTechnologies/tyk-pump#configuration
 pump:
+  enabled: false
   replicaCount: 1
   image:
     repository: tykio/tyk-pump-docker-pub

--- a/values_community_edition.yaml
+++ b/values_community_edition.yaml
@@ -5,9 +5,6 @@
 nameOverride: ""
 fullnameOverride: "tyk-headless"
 
-# Only set this to false if you are not planning on using the sidecar injector
-enableSharding: false
-
 secrets:
   APISecret: "CHANGEME"
   OrgID: "1"


### PR DESCRIPTION
There are some weird things with the headless helm chart i'm trying to address.

1. Disable sharding and tags - with the OSS gateway the default behaviour is based around 1 GW so lets not introduce that complexity. Having it enabled is an artifact from the deprecated service mesh piece.
2. For some reason the chart assumes a mongo is deployed even though we say it is not necessary in the readme - this means we are harming gateway performance by producing analytics and either sending to Redis where it is purged or we send to a Mongo instance which relies on a Tyk Dashboard to visualise. Instead we should look at how to accommodate open source options for defaults in another PR. Suggestions welcome!