### PR TITLE
Correct problems with chart start and missing deprecated values

### DIFF
--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Hybrid Gateway, assumes Redis has already been installed
 name: tyk-hybrid
-version: 0.4.0
+version: 0.4.1

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -78,9 +78,9 @@ spec:
           - name: TYK_GW_HTTPSERVEROPTIONS_USESSL
             value: "{{ .Values.gateway.tls }}"
           - name: TYK_GW_SLAVEOPTIONS_RPCKEY
-            value: "{{ default .Values.tyk_k8s.org_id .Values.rpc.rpcKey }}"
+            value: "{{ default .Values.tyk_k8s.org_id .Values.gateway.rpc.rpcKey }}"
           - name: TYK_GW_SLAVEOPTIONS_APIKEY
-            value: "{{ default .Values.tyk_k8s.dash_key .Values.rpc.apiKey }}"
+            value: "{{ default .Values.tyk_k8s.dash_key .Values.gateway.rpc.apiKey }}"
           - name: TYK_GW_SECRET
             value: "{{ .Values.secrets.APISecret }}"
           - name: TYK_GW_SLAVEOPTIONS_CONNECTIONSTRING

--- a/values_hybrid.yaml
+++ b/values_hybrid.yaml
@@ -90,3 +90,8 @@ gateway:
   extraEnvs: []
 
 rbac: true
+
+# deprecated - please use the rpcKey and apiKey in the gateway section
+tyk_k8s:
+  dash_key: ""
+  org_id: ""


### PR DESCRIPTION
We were getting the error 

Error: template: tyk-hybrid/templates/deployment-gw-repset.yaml:81:38: executing "tyk-hybrid/templates/deployment-gw-repset.yaml" at <.Values.tyk_k8s.org_id>: nil pointer evaluating interface {}.org_id

When running the chart because the default fallback is the old values for orgID and apiKey.