### PR TITLE
[TD-37] Roll using rand method instead of template hash

### DIFF
--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -34,7 +34,7 @@ spec:
         app: gateway-{{ include "tyk-headless.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-gw-repset.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:

--- a/tyk-headless/templates/deployment-pmp.yaml
+++ b/tyk-headless/templates/deployment-pmp.yaml
@@ -20,7 +20,7 @@ spec:
         app: pump-{{ include "tyk-headless.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-pmp.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
 {{- if .Values.pump.nodeSelector }}
       nodeSelector:

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -34,7 +34,7 @@ spec:
         app: gateway-{{ include "tyk-hybrid.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-gw-repset.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -30,7 +30,7 @@ spec:
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.dash.containerPort }}"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       {{- end }}
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-dash.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
 {{- if .Values.dash.nodeSelector }}
       nodeSelector:

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -41,7 +41,7 @@ spec:
         app: gateway-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-gw-repset.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:

--- a/tyk-pro/templates/deployment-mdcb.yaml
+++ b/tyk-pro/templates/deployment-mdcb.yaml
@@ -27,7 +27,7 @@ spec:
         app: mdcb-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-mdcb.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
 {{- if .Values.mdcb.nodeSelector }}
       nodeSelector:

--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -20,7 +20,7 @@ spec:
         release: {{ .Release.Name }}
     {{- if .Values.pump.annotations }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-pmp.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
       {{- range $key, $value := .Values.pump.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -27,7 +27,7 @@ spec:
         app: tib-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-tib.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
 {{- if .Values.tib.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
The previous roll method caused recursion errors because of self referencing templates.

Instead to self roll a dep you can use the rand method detailed in the helm docs here: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

We should also document the behaviour for helm upgrade that you get because of this since before someone would need the deprecated --recreate-pods flag to roll their pods