### PR TITLE
tyk-headless: Mount apps,middleware and policies directories

### DIFF
--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -104,6 +104,12 @@ spec:
             mountPath: /etc/certs
           - name: tyk-scratch
             mountPath: /mnt/tyk-gateway
+          - name: tyk-scratch
+            mountPath: /mnt/tyk-gateway/apps
+          - name: tyk-scratch
+            mountPath: /mnt/tyk-gateway/middleware
+          - name: tyk-scratch
+            mountPath: /mnt/tyk-gateway/policies
         livenessProbe:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"


### PR DESCRIPTION
 For tyk-headless deploying the chart and trying to create new api results in
 the following error

 ```
Failed to create file! - open /mnt/tyk-gateway/apps/YmRkL3dvcmthcm91bmQtYXBp.json: no such file or directory
 ```

The gateway assumes `/mnt/tyk-gateway/apps` is a directory that already exists,
however we only mount `/mnt/tyk-gateway` which means we need to create `apps`
sub directory for thw gateway to work

 This PR ensures that `apps`, `middleware` and `policies` directories are
 properly mounted making the gateway happy when creating/updating and deleting
 api's and policies

With this patch, the error above will not happen and the gateway will work as expected