### PR TITLE
[TD-37] Checksum configmaps

### DIFF
--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -34,7 +34,7 @@ spec:
         app: gateway-{{ include "tyk-headless.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-gw-repset.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-gateway.yaml") . | sha256sum }}
     spec:
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -34,7 +34,7 @@ spec:
         app: gateway-{{ include "tyk-hybrid.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-gw-repset.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-gateway.yaml") . | sha256sum }}
     spec:
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -30,7 +30,7 @@ spec:
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.dash.containerPort }}"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       {{- end }}
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-dash.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-dashboard.yaml") . | sha256sum }}
     spec:
 {{- if .Values.dash.nodeSelector }}
       nodeSelector:

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -41,7 +41,7 @@ spec:
         app: gateway-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/deployment-gw-repset.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-gateway.yaml") . | sha256sum }}
     spec:
 {{- if .Values.gateway.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Fixes #84

Fixes checksum/config annotation to use correct config maps instead of self
referencing deployment (That was leading to recursion)