### PR TITLE
tyk-headless: Setup directories needed for tyk to be operational

### DIFF
--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -48,6 +48,14 @@ spec:
       affinity:
 {{ toYaml .Values.gateway.affinity | indent 8 }}
 {{- end }}
+      initContainers: 
+      - name: "setup-directories"
+        image: busybox
+        command: ['sh','-c','mkdir -p apps && mkdir -p middlewares && mkdir -p policies']
+        workingDir: /mnt/tyk-gateway
+        volumeMounts:
+          - name: tyk-scratch
+            mountPath: /mnt/tyk-gateway        
       containers:
       - name: gateway-{{ .Chart.Name }}
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -50,7 +50,7 @@ spec:
 {{- end }}
       initContainers: 
       - name: "setup-directories"
-        image: busybox
+        image: busybox:1.32
         command: ['sh','-c','mkdir -p apps && mkdir -p middlewares && mkdir -p policies']
         workingDir: /mnt/tyk-gateway
         volumeMounts:

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers: 
       - name: "setup-directories"
         image: busybox:1.32
-        command: ['sh','-c','mkdir -p apps && mkdir -p middlewares && mkdir -p policies']
+        command: ['sh','-c','mkdir -p apps middleware policies']
         workingDir: /mnt/tyk-gateway
         volumeMounts:
           - name: tyk-scratch


### PR DESCRIPTION
Based on the solution proposed here https://github.com/TykTechnologies/tyk-helm-chart/pull/93#pullrequestreview-614090651

For tyk-headless deploying the chart and trying to create new api results in
the following error

 ```
Failed to create file! - open /mnt/tyk-gateway/apps/YmRkL3dvcmthcm91bmQtYXBp.json: no such file or directory
 ```

The gateway assumes `/mnt/tyk-gateway/apps` is a directory that already exists,
however we only mount `/mnt/tyk-gateway` which means we need to create `apps`
sub directory for thw gateway to work

 This PR ensures that `apps`, `middleware` and `policies` directories are
 properly created making the gateway happy when creating/updating and deleting
 api's and policies

This used init container to setup the directories