### PR TITLE
injects portal path as config env variable into dashboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ To install, *first modify the `values.yaml` file inside tyk-pro chart to add you
 
 Follow the instructions in the Notes that follow the installation to find your Tyk login credentials.
 
+### Tyk Developer Portal
+
+Once the Tyk Stack is up and running, take the following steps in order to bootstrap the Tyk Developer Portal:
+1. Set the portal domain via the Dashboard UI
+2. Restart the Dashboard containers
+3. Create a Default home page through the UI
+
 ## Install Tyk Hybrid Gateways (This can be used either for Hybrid Gateways connected to Tyk Cloud or MDCB Hybrid Gateways)
 
 To install, *first modify `values.yaml` file inside tyk-hybrid chart as follows:*

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -96,7 +96,7 @@ spec:
           - name: TYK_DB_LICENSEKEY
             value: {{ .Values.dash.license | quote }}
           - name: TYK_DB_HOSTCONFIG_PORTALROOTPATH
-            value:  {{ .Values.portal.ingress.path }}
+            value:  {{ .Values.portal.path }}
         {{- if .Values.dash.extraEnvs }}
         {{- range $env := .Values.dash.extraEnvs }}
           - name: {{ $env.name }}

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -95,6 +95,8 @@ spec:
             value: "{{ .Values.secrets.APISecret }}"
           - name: TYK_DB_LICENSEKEY
             value: {{ .Values.dash.license | quote }}
+          - name: TYK_DB_HOSTCONFIG_PORTALROOTPATH
+            value:  {{ .Values.portal.ingress.path }}
         {{- if .Values.dash.extraEnvs }}
         {{- range $env := .Values.dash.extraEnvs }}
           - name: {{ $env.name }}

--- a/tyk-pro/templates/ingress-portal.yaml
+++ b/tyk-pro/templates/ingress-portal.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.portal.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
-{{- $ingressPath := .Values.portal.ingress.path -}}
+{{- $ingressPath := .Values.portal.path -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -150,12 +150,12 @@ dash:
   extraEnvs: []
 
 portal:
+  path: /
   ingress:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-    path: /
     hosts:
       - tyk-portal.local
     tls: []


### PR DESCRIPTION
The Tyk Developer Portal `path` currently being read from the `tyk_analytics.conf`. This PR changes this in order to inject the portal path from the `values.yaml` into the Dashboard as an environment variable.

Also, I moved the `portal.ingress.path` to `portal.path` because the value applies to the Portal globally, even outside of any Ingress objects created.  Furthermore, there is a `portal.ingress.enabled` section which will be confusing if that is set to `false`, yet we are still injecting the `path` into an environment variable.