### PR TITLE
tyk-pro: ensure checksum/config for pump deployment is set

### DIFF
--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -18,13 +18,11 @@ spec:
       labels:
         app: pump-{{ include "tyk-pro.fullname" . }}
         release: {{ .Release.Name }}
-    {{- if .Values.pump.annotations }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-pump.yaml") . | sha256sum }}
       {{- range $key, $value := .Values.pump.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-    {{- end }}
     spec:
 {{- if .Values.pump.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
This change make sure that checksum/config is set even when
`.Values.pump.annotations` is not set

To reproduce the issue, just comment  `annotations` line in `pump` section of `values.yaml` this will create the pod without the checksum annotation.
