### PR TITLE
[TD-219] Tyk Pro bootstrap

### DIFF
--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -170,4 +170,4 @@ kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
   --from-literal "TYK_URL=${DASHBOARD_HOSTNAME}"
 
 # restart dashboard deployment
-kubectl rollout restart deployment/dashboard-tyk-pro
+kubectl rollout restart deployment/${TYK_DASHBOARD_DEPLOY}

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -59,6 +59,8 @@ spec:
           - name: BOOTSTRAP_PORTAL
             value: "true"
           {{- end }}
+          - name: TYK_DASHBOARD_DEPLOY
+            value: dashboard-{{ include "tyk-pro.fullname" . }}
         volumeMounts:
           - name: bootstrap-config-volume
             mountPath: /opt/scripts

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -14,6 +14,7 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  backoffLimit: 1
   template:
     metadata:
       annotations:

--- a/tyk-pro/templates/bootstrap-role.yml
+++ b/tyk-pro/templates/bootstrap-role.yml
@@ -16,3 +16,6 @@ rules:
   - get
   - list
   - create
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get","list","create","update","patch"]

--- a/tyk-pro/templates/bootstrap-role.yml
+++ b/tyk-pro/templates/bootstrap-role.yml
@@ -18,4 +18,4 @@ rules:
   - create
 - apiGroups: ["apps"]
   resources: ["deployments"]
-  verbs: ["get","list","create","update","patch"]
+  verbs: ["get","update","patch"]


### PR DESCRIPTION
A couple of things i missed in #105. 

- Grant post-install hook job access to restart dashboard deployment
- Allow hooks to retry only once because if the job is retried number of times the script will bootstrap from scratch each time causing `ORG DATA: {"Status":"Error","Message":"Failed to save new Org object to DB","Meta":null}
ORG ID: null` error
- Use dashboard deployment name as an environment variable in the bootstrap script