### PR TITLE
Helm updates

### DIFF
--- a/tyk-headless/Chart.yaml
+++ b/tyk-headless/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Gateway, assumes that MongoDB and Redis have already been installed
 name: tyk-headless
-version: 0.8.0
+version: 0.8.1

--- a/tyk-headless/values.yaml
+++ b/tyk-headless/values.yaml
@@ -3,34 +3,34 @@
 # Declare variables to be passed into your templates.
 
 nameOverride: ""
-fullnameOverride: "tyk-headless"
+fullnameOverride: tyk-headless
 
 secrets:
-  APISecret: "CHANGEME"
-  OrgID: "1"
+  APISecret: CHANGEME
+  OrgID: 1
 
 redis:
     shardCount: 128
     addrs:
-      - "redis.tyk.svc.cluster.local:6379"
+      - redis.tyk.svc.cluster.local:6379
     useSSL: false
     #If you're using Bitnami Redis chart please input the correct host to your installation in the field below
     #addrs:
-      #- "tyk-redis-master.tyk.svc.cluster.local:6379"
+      #- tyk-redis-master.tyk.svc.cluster.local:6379
     #If you're using Bitnami Redis chart please input your password in the field below
       #pass: ""
 
 mongo:
   enabled: false
-#    mongoURL: "mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics"
+#    mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
 #    #If you're using Bitnami MongoDB chart please input your password below
-#    #mongoURL: "mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin"
+#    #mongoURL: mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin
 #    useSSL: false
 
 gateway:
   kind: DaemonSet
   replicaCount: 1
-  hostName: "tyk-gw.local"
+  hostName: tyk-gw.local
   tls: false
   containerPort: 8080
   tags: ""
@@ -53,7 +53,7 @@ gateway:
     enabled: false
     annotations: {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/tls-acme: true
     path: /
     hosts:
       - tyk-gw.local

--- a/tyk-headless/values.yaml
+++ b/tyk-headless/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: tyk-headless
 
 secrets:
   APISecret: CHANGEME
-  OrgID: 1
+  OrgID: "1"
 
 redis:
     shardCount: 128
@@ -53,7 +53,7 @@ gateway:
     enabled: false
     annotations: {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: true
+    # kubernetes.io/tls-acme: "true"
     path: /
     hosts:
       - tyk-gw.local

--- a/tyk-headless/values.yaml
+++ b/tyk-headless/values.yaml
@@ -31,7 +31,7 @@ gateway:
   kind: DaemonSet
   replicaCount: 1
   hostName: "tyk-gw.local"
-  tls: true
+  tls: false
   containerPort: 8080
   tags: ""
   image:

--- a/tyk-headless/values.yaml
+++ b/tyk-headless/values.yaml
@@ -30,7 +30,7 @@ mongo:
 gateway:
   kind: DaemonSet
   replicaCount: 1
-  hostName: "gateway.tykbeta.com"
+  hostName: "tyk-gw.local"
   tls: true
   containerPort: 8080
   tags: ""

--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Hybrid Gateway, assumes Redis has already been installed
 name: tyk-hybrid
-version: 0.5.0
+version: 0.5.1

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -9,15 +9,15 @@ enableSharding: false
 hybrid: true
 
 secrets:
-  APISecret: "CHANGEME"
+  APISecret: CHANGEME
 
 redis:
     shardCount: 128
     #If you're using Bitnami Redis chart please input the correct host to your instalaltion in the field below
     #addrs:
-    #- "tyk-redis-master.tyk.svc.cluster.local:6379"
+    #- tyk-redis-master.tyk.svc.cluster.local:6379
     addrs:
-      - "redis.tyk.svc.cluster.local:6379"
+      - redis.tyk.svc.cluster.local:6379
     useSSL: false
     #If you're using Bitnami Redis chart please input your password in the field below
     #pass: ""
@@ -28,7 +28,7 @@ gateway:
   replicaCount: 2
   # if enableSharding set to true then you must define a tag to load APIs to these gateways i.e. "ingress"
   tags: ""
-  hostName: "tyk-gw.local"
+  hostName: tyk-gw.local
   tls: false
   containerPort: 8080
   # For on premise MDCB setups simply change the connection string to point to your MDCB instance
@@ -63,7 +63,7 @@ gateway:
     enabled: false
     annotations: {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/tls-acme: true
     path: /
     hosts:
       - tyk-gw.local

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -63,7 +63,7 @@ gateway:
     enabled: false
     annotations: {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: true
+    # kubernetes.io/tls-acme: "true"
     path: /
     hosts:
       - tyk-gw.local

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -28,7 +28,7 @@ gateway:
   replicaCount: 2
   # if enableSharding set to true then you must define a tag to load APIs to these gateways i.e. "ingress"
   tags: ""
-  hostName: ""
+  hostName: "tyk-gw.local"
   tls: true
   containerPort: 8080
   # For on premise MDCB setups simply change the connection string to point to your MDCB instance

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -29,7 +29,7 @@ gateway:
   # if enableSharding set to true then you must define a tag to load APIs to these gateways i.e. "ingress"
   tags: ""
   hostName: "tyk-gw.local"
-  tls: true
+  tls: false
   containerPort: 8080
   # For on premise MDCB setups simply change the connection string to point to your MDCB instance
   rpc:

--- a/tyk-pro/Chart.yaml
+++ b/tyk-pro/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Dashboard, assumes that MongoDB and Redis have already been installed
 name: tyk-pro
-version: 0.8.0
+version: 0.8.1

--- a/tyk-pro/configs/tyk_analytics.conf
+++ b/tyk-pro/configs/tyk_analytics.conf
@@ -27,7 +27,7 @@
     "portal_root_path": "/"
   },
   "home_dir": "/opt/tyk-dashboard",
-  "use_sharded_analytics": true,
+  "use_sharded_analytics": false,
   "enable_aggregate_lookups": true,
   "enable_analytics_cache": true,
   "allow_explicit_policy_id": true,

--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -160,8 +160,10 @@ log_ok(){
   log_message "  Ok"
 }
 
-
-main $DASHBOARD_HOSTNAME
+if [ "$BOOTSTRAP_DASHBOARD" = "true" ]
+then
+  main $DASHBOARD_HOSTNAME
+fi
 
 kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
   --from-literal "TYK_AUTH=${USER_AUTH_CODE}" \

--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-
-apk --no-cache add curl jq
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-
 DASHBOARD_HOSTNAME="http://$TYK_DASHBOARD_SVC.$TYK_POD_NAMESPACE.svc.cluster.local:$TYK_DB_LISTENPORT"
 
 main(){
@@ -13,9 +8,6 @@ main(){
   then
     syntax_message
   else
-    # Sleep for 10 seconds to allow for dashboard to come up.
-    sleep 10
-
     generate_credentials "$DASHBOARD_HOSTNAME"
     exit_reason "$?"
     if [ "$BOOTSTRAP_PORTAL" = "true" ]

--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -13,6 +13,9 @@ main(){
   then
     syntax_message
   else
+    # Sleep for 10 seconds to allow for dashboard to come up.
+    sleep 10
+
     generate_credentials "$DASHBOARD_HOSTNAME"
     exit_reason "$?"
     if [ "$BOOTSTRAP_PORTAL" = "true" ]

--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -160,7 +160,7 @@ log_ok(){
   log_message "  Ok"
 }
 
-if [ "$BOOTSTRAP_DASHBOARD" = "true" ]
+if [ "$DASHBOARD_ENABLED" = "true" ] && [ "$BOOTSTRAP_DASHBOARD" = "true" ]
 then
   main $DASHBOARD_HOSTNAME
 fi
@@ -171,5 +171,8 @@ kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
   --from-literal "TYK_MODE=pro" \
   --from-literal "TYK_URL=${DASHBOARD_HOSTNAME}"
 
-# restart dashboard deployment
-kubectl rollout restart deployment/${TYK_DASHBOARD_DEPLOY}
+if [ "$DASHBOARD_ENABLED" = "true" ]
+then
+  # restart dashboard deployment
+  kubectl rollout restart deployment/${TYK_DASHBOARD_DEPLOY}
+fi

--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-DASHBOARD_HOSTNAME="http://$TYK_DASHBOARD_SVC.$TYK_POD_NAMESPACE.svc.cluster.local:$TYK_DB_LISTENPORT"
+DASHBOARD_HOSTNAME="$TYK_DASHBOARD_PROTO://$TYK_DASHBOARD_SVC.$TYK_POD_NAMESPACE.svc.cluster.local:$TYK_DB_LISTENPORT"
 
 main(){
   if [[ $# -lt 1 ]]

--- a/tyk-pro/scripts/init.sh
+++ b/tyk-pro/scripts/init.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+apk --no-cache add curl jq
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+/opt/scripts/wait-for-it.sh -t 120 $TYK_DASHBOARD_SVC.$TYK_POD_NAMESPACE.svc.cluster.local:$TYK_DB_LISTENPORT && \
+/opt/scripts/bootstrap.sh

--- a/tyk-pro/scripts/wait-for-it.sh
+++ b/tyk-pro/scripts/wait-for-it.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+WAITFORIT_NO_BUSYTIMEFLAG=1
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ ! -z "${WAITFORIT_NO_BUSYTIMEFLAG}" ]]; then
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -1,4 +1,4 @@
-- The Dashboard is bootstrapped automatically, to find Login details please run those commands inside your tyk namespace:
+- If you enabled the Dashboard bootstraping option (.Value.dash.bootstrap), you can find the login details by running the following commands inside your {{ .Release.Namespace }} namespace:
 
 For the URL: (kubectl get nodes --selector=kubernetes.io/role!=master -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}'), if you're using Minikube then: (minikube ip) would be sufficient"
 For the port: (kubectl get --namespace tyk -o jsonpath="{.spec.ports[0].nodePort}" services dashboard-svc-tyk-pro)"
@@ -16,4 +16,5 @@ You might want to install Tyk Operator next to manage Ingress resources or manag
 
 [Tyk Operator](https://github.com/TykTechnologies/tyk-operator/)
 
-Inside tyk namespace there is secret named: "tyk-operator-conf", which is automatically created and can be used with our Tyk Operator.
+Inside tyk namespace there is secret named: "tyk-operator-conf", which is used by our Tyk Operator. 
+This is created by default and can be tuned off by setting the .Values.bootstrap to false.

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -46,6 +46,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: TYK_DASHBOARD_PROTO
+            value: {{ include "tyk-pro.dash_proto" . }}
           - name: TYK_DASHBOARD_SVC
             value: dashboard-svc-{{ include "tyk-pro.fullname" . }}
           - name: TYK_DB_LISTENPORT

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -28,7 +28,7 @@ spec:
         command: 
         - sh
         - -c
-        - /opt/scripts/bootstrap.sh
+        - /opt/scripts/init.sh
         env:
           - name: TYK_ADMIN_FIRST_NAME
             value: {{ .Values.dash.adminUser.firstName | quote }}

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.bootstrap -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -79,3 +80,5 @@ spec:
             defaultMode: 0777
       restartPolicy: Never
       terminationGracePeriodSeconds: 0
+{{- end }}
+      

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -55,6 +55,10 @@ spec:
             value: {{ .Values.dash.org.name | quote }}
           - name: TYK_ORG_CNAME
             value: {{ .Values.dash.org.cname | quote }}
+          {{- if .Values.dash.enabled }}
+          - name: DASHBOARD_ENABLED
+            value: "true"
+          {{- end }}
           {{- if .Values.dash.bootstrap }}
           - name: BOOTSTRAP_DASHBOARD
             value: "true"

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -55,6 +55,10 @@ spec:
             value: {{ .Values.dash.org.name | quote }}
           - name: TYK_ORG_CNAME
             value: {{ .Values.dash.org.cname | quote }}
+          {{- if .Values.dash.bootstrap }}
+          - name: BOOTSTRAP_DASHBOARD
+            value: "true"
+          {{- end }}
           {{- if .Values.portal.bootstrap }}
           - name: BOOTSTRAP_PORTAL
             value: "true"

--- a/tyk-pro/templates/bootstrap-role-binding.yml
+++ b/tyk-pro/templates/bootstrap-role-binding.yml
@@ -1,3 +1,4 @@
+{{- if .Values.bootstrap -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -10,3 +11,4 @@ roleRef:
   kind: Role
   name: k8s-bootstrap-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/tyk-pro/templates/bootstrap-role.yml
+++ b/tyk-pro/templates/bootstrap-role.yml
@@ -1,3 +1,4 @@
+{{- if .Values.bootstrap -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -19,3 +20,4 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["get","update","patch"]
+{{- end }}

--- a/tyk-pro/templates/bootstrap-service.yml
+++ b/tyk-pro/templates/bootstrap-service.yml
@@ -1,4 +1,6 @@
+{{- if .Values.bootstrap -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: k8s-bootstrap-role
+{{- end }}

--- a/tyk-pro/templates/configmap-dashboard.yaml
+++ b/tyk-pro/templates/configmap-dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dash.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,3 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   {{- (.Files.Glob "configs/tyk_analytics.conf").AsConfig | nindent 2 }}
+{{- end }}

--- a/tyk-pro/templates/configmap-gateway.yaml
+++ b/tyk-pro/templates/configmap-gateway.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,3 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   {{- (.Files.Glob "configs/tyk_mgmt.conf").AsConfig | nindent 2 }}
+{{- end }}

--- a/tyk-pro/templates/configmap-post-install-bootstrap.yaml
+++ b/tyk-pro/templates/configmap-post-install-bootstrap.yaml
@@ -3,5 +3,9 @@ kind: ConfigMap
 metadata:
   name: bootstrap-post-install-configmap-{{ include "tyk-pro.fullname" . }}
 data:
+  init.sh: |-
+{{ .Files.Get "scripts/init.sh" | indent 4 }}
   bootstrap.sh: |-
 {{ .Files.Get "scripts/bootstrap.sh" | indent 4 }}
+  wait-for-it.sh: |-
+{{ .Files.Get "scripts/wait-for-it.sh" | indent 4 }}

--- a/tyk-pro/templates/configmap-pump.yaml
+++ b/tyk-pro/templates/configmap-pump.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pump.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,3 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   {{- (.Files.Glob "configs/pump.conf").AsConfig | nindent 2 }}
+{{- end }}

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dash.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -136,3 +137,4 @@ spec:
             items:
               - key: tyk_analytics.conf
                 path: tyk_analytics.conf
+{{- end }}

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -70,6 +70,12 @@ spec:
             value: "{{ include "tyk-pro.gwproto" . }}://gateway-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
           - name: TYK_DB_TYKAPI_PORT
             value: "{{ .Values.gateway.service.port }}"
+          {{- if .Values.gateway.control.enabled }}
+          - name: TYK_DB_TYKAPI_HOST
+            value: "{{ include "tyk-pro.gwproto" . }}://gateway-control-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
+          - name: TYK_DB_TYKAPI_PORT
+            value: "{{ .Values.gateway.control.containerPort }}"
+          {{- end }}
           - name: TYK_DB_TYKAPI_SECRET
             value: "{{ .Values.secrets.APISecret }}"
           - name: TYK_DB_REDISADDRS

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.enabled -}}
 apiVersion: apps/v1
 kind: {{ .Values.gateway.kind }}
 metadata:
@@ -146,3 +147,4 @@ spec:
         - name: {{ .Release.Name }}-default-cert
           secret:
             secretName: {{ .Release.Name }}-default-cert
+{{- end }}

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -71,6 +71,10 @@ spec:
         env:
           - name: TYK_GW_LISTENPORT
             value: "{{ .Values.gateway.containerPort }}"
+          {{- if .Values.gateway.control.enabled }}
+          - name: TYK_GW_CONTROLAPIPORT
+            value: "{{ .Values.gateway.control.containerPort }}"
+          {{- end }}
           - name: REDIGOCLUSTER_SHARDCOUNT
             value: "{{ .Values.redis.shardCount }}"
           - name: TYK_GW_STORAGE_ADDRS
@@ -105,6 +109,9 @@ spec:
         workingDir: /opt/tyk-gateway
         ports:
         - containerPort: {{ .Values.gateway.containerPort }}
+        {{- if .Values.gateway.control.enabled -}}
+        - containerPort: {{ .Values.gateway.control.containerPort }}
+        {{- end }}
         resources:
 {{ toYaml .Values.gateway.resources | indent 12 }}
         volumeMounts:

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -90,9 +90,9 @@ spec:
           - name: TYK_GW_DBAPPCONFOPTIONS_NODEISSEGMENTED
             value: "{{ .Values.enableSharding }}"
           - name: TYK_GW_DBAPPCONFOPTIONS_CONNECTIONSTRING
-            value: "http://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
+            value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
           - name: TYK_GW_POLICIES_POLICYCONNECTIONSTRING
-            value: "http://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
+            value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
           - name: TYK_GW_SECRET
             value: "{{ .Values.secrets.APISecret }}"
           - name: TYK_GW_NODESECRET

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -72,6 +72,8 @@ spec:
           - name: TYK_GW_LISTENPORT
             value: "{{ .Values.gateway.containerPort }}"
           {{- if .Values.gateway.control.enabled }}
+          - name: TYK_GW_CONTROLAPIHOSTNAME
+            value: "{{ include "tyk-pro.gwproto" . }}://gateway-control-svc-{{  include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
           - name: TYK_GW_CONTROLAPIPORT
             value: "{{ .Values.gateway.control.containerPort }}"
           {{- end }}

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -109,7 +109,7 @@ spec:
         workingDir: /opt/tyk-gateway
         ports:
         - containerPort: {{ .Values.gateway.containerPort }}
-        {{- if .Values.gateway.control.enabled -}}
+        {{- if .Values.gateway.control.enabled }}
         - containerPort: {{ .Values.gateway.control.containerPort }}
         {{- end }}
         resources:

--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pump.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -90,3 +91,4 @@ spec:
             items:
               - key: pump.conf
                 path: pump.conf
+{{- end}}

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -69,7 +69,7 @@ spec:
           - name: TYK_IB_TYKAPISETTINGS_GATEWAYCONFIG_ADMINSECRET
             value: "{{ .Values.secrets.AdminSecret }}"
           - name: TYK_IB_TYKAPISETTINGS_DASHBOARDCONFIG_ENDPOINT
-            value: "http://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
+            value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
           - name: TYK_IB_TYKAPISETTINGS_DASHBOARDCONFIG_PORT
             value: "{{ .Values.dash.service.port }}"
         {{- if .Values.tib.extraEnvs }}

--- a/tyk-pro/templates/ingress-dash.yaml
+++ b/tyk-pro/templates/ingress-dash.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dash.ingress.enabled -}}
+{{- if and .Values.dash.enabled .Values.dash.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
 {{- $ingressPath := .Values.dash.ingress.path -}}
 apiVersion: networking.k8s.io/v1beta1

--- a/tyk-pro/templates/ingress-gw.yaml
+++ b/tyk-pro/templates/ingress-gw.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.ingress.enabled -}}
+{{- if and .Values.gateway.enabled .Values.gateway.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
 {{- $ingressPath := .Values.gateway.ingress.path -}}
 apiVersion: networking.k8s.io/v1beta1

--- a/tyk-pro/templates/ingress-portal.yaml
+++ b/tyk-pro/templates/ingress-portal.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.portal.ingress.enabled -}}
+{{- if and .Values.portal.enabled .Values.portal.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
 {{- $ingressPath := .Values.portal.path -}}
 apiVersion: networking.k8s.io/v1beta1

--- a/tyk-pro/templates/ingress-portal.yaml
+++ b/tyk-pro/templates/ingress-portal.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.portal.enabled .Values.portal.ingress.enabled -}}
+{{- if .Values.portal.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
 {{- $ingressPath := .Values.portal.path -}}
 apiVersion: networking.k8s.io/v1beta1

--- a/tyk-pro/templates/service-dash.yaml
+++ b/tyk-pro/templates/service-dash.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dash.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
   selector:
     app: dashboard-{{ include "tyk-pro.fullname" . }}
     release: {{ .Release.Name }}
+{{- end}} 

--- a/tyk-pro/templates/service-gw-control.yaml
+++ b/tyk-pro/templates/service-gw-control.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.gateway.control.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-control-svc-{{ include "tyk-pro.fullname" . }}
+  labels:
+    app: gateway-control-svc-{{ include "tyk-pro.fullname" . }}
+    chart: {{ include "tyk-pro.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.gateway.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.gateway.control.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+spec:
+  type: {{ .Values.gateway.control.type }}
+  ports:
+  - port: {{ .Values.gateway.control.port }}
+    targetPort: {{ .Values.gateway.control.containerPort }}
+    protocol: TCP
+  selector:
+    app: gateway-{{ include "tyk-pro.fullname" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/tyk-pro/templates/service-gw.yaml
+++ b/tyk-pro/templates/service-gw.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -26,3 +27,4 @@ spec:
 {{- if eq .Values.gateway.service.type "LoadBalancer" }}
   externalTrafficPolicy: {{ .Values.gateway.service.externalTrafficPolicy }}
 {{- end }}
+{{- end }} 

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -111,7 +111,7 @@ tib:
 
 dash:
   replicaCount: 1
-  hostName: "localhost"
+  hostName: "tyk-dashboard.local"
   license: ""
   containerPort: 3000
   image:
@@ -158,7 +158,7 @@ dash:
   org:
     name: Default Org
     # Set this value to the domain of your developer portal
-    cname: "localhost"
+    cname: "tyk-portal.local"
 
 portal:
   # Only set this to false if you're not planning on using developer portal
@@ -179,7 +179,7 @@ portal:
 gateway:
   kind: DaemonSet
   replicaCount: 2
-  hostName: "gateway.tykbeta.com"
+  hostName: "tyk-gw.local"
   tags: "ingress"
   tls: true
   containerPort: 8080

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -65,7 +65,6 @@ mdcb:
   affinity: {}
   extraEnvs: []
 
-
 tib:
   enabled: false
   useSSL: true
@@ -110,6 +109,7 @@ tib:
     profiles: tyk-tib-profiles-conf
 
 dash:
+  bootstrap: true
   replicaCount: 1
   hostName: "tyk-dashboard.local"
   license: ""
@@ -161,6 +161,7 @@ dash:
     cname: "tyk-portal.local"
 
 portal:
+  # You can only bootstrap the Developer Portal if the Dashboard boostrap option is also enabled
   # Only set this to false if you're not planning on using developer portal
   bootstrap: true
   path: /

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -113,6 +113,7 @@ tib:
 
 dash:
   enabled: true
+  # Dashboard will only bootstrap if the master bootstrap option is set to true
   bootstrap: true
   replicaCount: 1
   hostName: tyk-dashboard.local
@@ -165,7 +166,7 @@ dash:
     cname: tyk-portal.local
 
 portal:
-  # You can only bootstrap the Developer Portal if the Dashboard boostrap option is also enabled
+  # Portal will only bootstrap if both the Master and Dashboard bootstrap options are set to true
   # Only set this to false if you're not planning on using developer portal
   bootstrap: true
   path: /

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -14,24 +14,24 @@ enableSharding: false
 enableIstioIngress: false
 
 secrets:
-  APISecret: "CHANGEME"
-  AdminSecret: "12345"
+  APISecret: CHANGEME
+  AdminSecret: 12345
 
 redis:
     shardCount: 128
     #If you're using Bitnami Redis chart please input the correct host to your instalaltion in the field below
     #addrs:
-    #- "tyk-redis-master.tyk.svc.cluster.local:6379"
+    #   - tyk-redis-master.tyk.svc.cluster.local:6379
     # addrs:
-    #   - "redis.tyk.svc.cluster.local:6379"
+    #   - redis.tyk.svc.cluster.local:6379
     useSSL: false
     #If you're using Bitnami Redis chart please input your password in the field below
     #pass: ""
 
 mongo:
-    # mongoURL: "mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics"
+    # mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
     #If you're using Bitnami MongoDB chart please input your password below
-    #mongoURL: "mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin"
+    #mongoURL: mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin
     useSSL: false
 
 mdcb:
@@ -81,7 +81,7 @@ tib:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/tls-acme: true
     path: /
     hosts:
       - tib.local
@@ -111,7 +111,7 @@ tib:
 dash:
   bootstrap: true
   replicaCount: 1
-  hostName: "tyk-dashboard.local"
+  hostName: tyk-dashboard.local
   license: ""
   containerPort: 3000
   image:
@@ -125,7 +125,7 @@ dash:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/tls-acme: true
     path: /
     hosts:
       - tyk-dashboard.local
@@ -158,7 +158,7 @@ dash:
   org:
     name: Default Org
     # Set this value to the domain of your developer portal
-    cname: "tyk-portal.local"
+    cname: tyk-portal.local
 
 portal:
   # You can only bootstrap the Developer Portal if the Dashboard boostrap option is also enabled
@@ -169,7 +169,7 @@ portal:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/tls-acme: true
     hosts:
       - tyk-portal.local
     tls: []
@@ -180,8 +180,9 @@ portal:
 gateway:
   kind: DaemonSet
   replicaCount: 2
-  hostName: "tyk-gw.local"
-  tags: "ingress"
+  hostName: tyk-gw.local
+  # if enableSharding set to true then you must define a tag to load APIs to these gateways i.e. "ingress"
+  tags: ""
   tls: false
   containerPort: 8080
   image:
@@ -197,7 +198,7 @@ gateway:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/tls-acme: true
     path: /
     hosts:
       - tyk-gw.local

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -13,6 +13,9 @@ enableSharding: false
 # Gateway and Dashboard are exposed to the outside world - see the deployment templates for implementation
 enableIstioIngress: false
 
+# Master switch for enabling/disabling bootstraing job batch, role binding, role, and account service.
+bootstrap: true
+
 secrets:
   APISecret: CHANGEME
   AdminSecret: "12345"

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -197,6 +197,12 @@ gateway:
     port: 8080
     externalTrafficPolicy: Local
     annotations: {}
+  control:
+    enabled: false
+    containerPort: 9696
+    port: 9696
+    type: ClusterIP
+    annotations: {}
   ingress:
     enabled: false
     annotations: {}

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -181,7 +181,7 @@ gateway:
   replicaCount: 2
   hostName: "tyk-gw.local"
   tags: "ingress"
-  tls: true
+  tls: false
   containerPort: 8080
   image:
     repository: tykio/tyk-gateway

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -109,6 +109,7 @@ tib:
     profiles: tyk-tib-profiles-conf
 
 dash:
+  enabled: true
   bootstrap: true
   replicaCount: 1
   hostName: tyk-dashboard.local
@@ -161,6 +162,7 @@ dash:
     cname: tyk-portal.local
 
 portal:
+  enabled: true
   # You can only bootstrap the Developer Portal if the Dashboard boostrap option is also enabled
   # Only set this to false if you're not planning on using developer portal
   bootstrap: true
@@ -178,6 +180,7 @@ portal:
     #      - chart-example.local
 
 gateway:
+  enabled: true
   kind: DaemonSet
   replicaCount: 2
   hostName: tyk-gw.local
@@ -225,6 +228,7 @@ gateway:
   extraEnvs: []
 
 pump:
+  enabled: true
   replicaCount: 1
   image:
     repository: tykio/tyk-pump-docker-pub

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -15,7 +15,7 @@ enableIstioIngress: false
 
 secrets:
   APISecret: CHANGEME
-  AdminSecret: 12345
+  AdminSecret: "12345"
 
 redis:
     shardCount: 128
@@ -126,7 +126,7 @@ dash:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: true
+      # kubernetes.io/tls-acme: "true"
     path: /
     hosts:
       - tyk-dashboard.local
@@ -171,7 +171,7 @@ portal:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: true
+      # kubernetes.io/tls-acme: "true"
     hosts:
       - tyk-portal.local
     tls: []
@@ -207,7 +207,7 @@ gateway:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: true
+      # kubernetes.io/tls-acme: "true"
     path: /
     hosts:
       - tyk-gw.local

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -162,7 +162,6 @@ dash:
     cname: tyk-portal.local
 
 portal:
-  enabled: true
   # You can only bootstrap the Developer Portal if the Dashboard boostrap option is also enabled
   # Only set this to false if you're not planning on using developer portal
   bootstrap: true


### PR DESCRIPTION
- Updated all default hostname values to mirror values used in the ingress section for the respective services. 
- Changed Gateway TLS to be disabled by default.
- Added the ability to disable Dashboard bootstrapping in the tyk-pro helm.
- Turned off the `use_sharded_analytics` option in the tyk-pro helm.
- Added the ability to disable different Tyk components in the tyk-pro helm.
- Added control API gateway functionality to the tyk-pro helm.
- Fixed bootstrap vs dashboard race issues. 
- Dynamically set dashboard URL protocol based on tls option under dash service in the tyk-pro helm.

Tickets resolved:
- https://tyktech.atlassian.net/browse/TD-251