### PR TITLE
Various small fixes

### DIFF
--- a/tyk-pro/templates/_helpers.tpl
+++ b/tyk-pro/templates/_helpers.tpl
@@ -40,11 +40,7 @@ http
 {{- end -}}
 
 {{- define "tyk-pro.dash_proto" -}}
-{{- if .Values.gateway.tls -}}
-https
-{{- else -}}
 http
-{{- end -}}
 {{- end -}}
 
 {{- define "tyk-pro.dash_url" -}}

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -17,8 +17,8 @@ enableIstioIngress: false
 bootstrap: true
 
 secrets:
-  APISecret: CHANGEME
-  AdminSecret: "12345"
+  APISecret: CHANGEME ## Gateway Master Secret
+  AdminSecret: "12345" ## Dashboard Master Secret, for Dashboard Admin API
 
 redis:
     shardCount: 128


### PR DESCRIPTION
1.  Hard coding the Dashboard to http as there is no option to enable TLS. Currently, we set the Dashboard protocol based off the Gateway TLS option which makes no sense. We can turn on the Gateway TLS and this leaves the Dashboard TLS off.

2.  Adding comments to explain the API secrets
