### PR TITLE
[TD-283] liveness and readiness probe to query control api

### DIFF
--- a/.github/tyk_ce_values.yaml
+++ b/.github/tyk_ce_values.yaml
@@ -3,40 +3,40 @@
 # Declare variables to be passed into your templates.
 
 nameOverride: ""
-fullnameOverride: "tyk-headless"
+fullnameOverride: tyk-headless
 
 secrets:
-  APISecret: "CHANGEME"
+  APISecret: CHANGEME
   OrgID: "1"
 
 redis:
     shardCount: 128
     addrs:
-      - "redis.tyk.svc.cluster.local:6379"
+      - redis.tyk.svc.cluster.local:6379
     useSSL: false
     #If you're using Bitnami Redis chart please input the correct host to your installation in the field below
     #addrs:
-      #- "tyk-redis-master.tyk.svc.cluster.local:6379"
+      #- tyk-redis-master.tyk.svc.cluster.local:6379
     #If you're using Bitnami Redis chart please input your password in the field below
       #pass: ""
 
 mongo:
   enabled: false
-#    mongoURL: "mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics"
+#    mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
 #    #If you're using Bitnami MongoDB chart please input your password below
-#    #mongoURL: "mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin"
+#    #mongoURL: mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin
 #    useSSL: false
 
 gateway:
   kind: DaemonSet
-  replicaCount: 2
-  hostName: "gateway.tykbeta.com"
-  tls: true
+  replicaCount: 1
+  hostName: tyk-gw.local
+  tls: false
   containerPort: 8080
   tags: ""
   image:
     repository: tykio/tyk-gateway
-    tag: v3.1.2
+    tag: v3.0.5
     pullPolicy: IfNotPresent
   service:
     type: NodePort
@@ -44,7 +44,7 @@ gateway:
     externalTrafficPolicy: Local
     annotations: {}
   control:
-    enabled: false
+    enabled: true
     containerPort: 9696
     port: 9696
     type: ClusterIP
@@ -82,8 +82,8 @@ gateway:
 # If pump is enabled the Gateway will create and collect analytics data to send to a data store of your choice
 # These can be set up in the pump config. The possible pump configs can be found here: https://github.com/TykTechnologies/tyk-pump#configuration
 pump:
-  enabled: true
-  replicaCount: 2
+  enabled: false
+  replicaCount: 1
   image:
     repository: tykio/tyk-pump-docker-pub
     tag: v1.2.0

--- a/.github/tyk_hybrid_values.yaml
+++ b/.github/tyk_hybrid_values.yaml
@@ -5,19 +5,19 @@
 nameOverride: ""
 fullnameOverride: ""
 
-enableSharding: true
+enableSharding: false
 hybrid: true
 
 secrets:
-  APISecret: "CHANGEME"
+  APISecret: CHANGEME
 
 redis:
     shardCount: 128
     #If you're using Bitnami Redis chart please input the correct host to your instalaltion in the field below
     #addrs:
-    #- "tyk-redis-master.tyk.svc.cluster.local:6379"
+    #- tyk-redis-master.tyk.svc.cluster.local:6379
     addrs:
-      - "redis.tyk.svc.cluster.local:6379"
+      - redis.tyk.svc.cluster.local:6379
     useSSL: false
     #If you're using Bitnami Redis chart please input your password in the field below
     #pass: ""
@@ -25,11 +25,11 @@ redis:
 gateway:
   kind: DaemonSet
   # Set replicaCount for Deployments
-  replicaCount: 3
+  replicaCount: 2
   # if enableSharding set to true then you must define a tag to load APIs to these gateways i.e. "ingress"
   tags: ""
-  hostName: ""
-  tls: true
+  hostName: tyk-gw.local
+  tls: false
   containerPort: 8080
   # For on premise MDCB setups simply change the connection string to point to your MDCB instance
   rpc:

--- a/.github/tyk_pro_values.yaml
+++ b/.github/tyk_pro_values.yaml
@@ -21,21 +21,26 @@ secrets:
   AdminSecret: "12345"
 
 redis:
-    shardCount: 128
-    #If you're using Bitnami Redis chart please input the correct host to your instalaltion in the field below
-    #addrs:
-    #   - tyk-redis-master.tyk.svc.cluster.local:6379
-    # addrs:
-    #   - redis.tyk.svc.cluster.local:6379
-    useSSL: false
-    #If you're using Bitnami Redis chart please input your password in the field below
-    #pass: ""
+  shardCount: 128
+  # addrs:
+  #   - redis.tyk.svc.cluster.local:6379
+  useSSL: false
+#    #If you're using Bitnami Redis chart please input the correct host to your installation in the field below
+#    addrs:
+#      - tyk-redis-master.tyk.svc.cluster.local:6379
+#   #If you're using Bitnami Redis chart please input your password in the field below
+#    pass: ""
+#   #If you are using Redis cluster, enable it here.
+#    enableCluster: false
+#   #By default the database index is 0. Setting the database index is not supported with redis cluster. As such, if you have enableCluster: true, then this value should be omitted or explicitly set to 0.
+  storage:
+    database: 0
 
 mongo:
-    # mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
-    #If you're using Bitnami MongoDB chart please input your password below
-    #mongoURL: mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin
-    useSSL: false
+  # mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
+  # If you're using Bitnami MongoDB chart please input your password below
+  # mongoURL: mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin
+  useSSL: false
 
 mdcb:
   enabled: false
@@ -46,7 +51,7 @@ mdcb:
   license: ""
   forwardAnalyticsToPump: true
   image:
-    repository: tykio/tyk-mdcb-docker #requires credential
+    repository: tykio/tyk-mdcb-docker    # requires credential
     tag: v1.7.7
     pullPolicy: Always
   service:
@@ -108,7 +113,7 @@ tib:
   affinity: {}
   extraEnvs: []
   configMap:
-    #Create a configMap to store profiles json
+    # Create a configMap to store profiles json
     profiles: tyk-tib-profiles-conf
 
 dash:
@@ -153,7 +158,7 @@ dash:
   tolerations: []
   affinity: {}
   extraEnvs: []
-  # Set these values for dashboard admin user 
+  # Set these values for dashboard admin user
   adminUser:
     firstName: admin
     lastName: user

--- a/.github/tyk_pro_values.yaml
+++ b/.github/tyk_pro_values.yaml
@@ -6,36 +6,39 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Used to shard the gateways. If you enable it make sure you have at least one gateway that is not sharded and also tag the APIs accordingly
-enableSharding: true
+enableSharding: false
 
 # Set to true to use Tyk as the Ingress gateway to an Istio Service Mesh
 # We apply some exceptions to the Istio IPTables so inbound calls to the
 # Gateway and Dashboard are exposed to the outside world - see the deployment templates for implementation
-enableIstioIngress: true
+enableIstioIngress: false
+
+# Master switch for enabling/disabling bootstraing job batch, role binding, role, and account service.
+bootstrap: true
 
 secrets:
-  APISecret: "CHANGEME"
+  APISecret: CHANGEME
   AdminSecret: "12345"
 
 redis:
     shardCount: 128
     #If you're using Bitnami Redis chart please input the correct host to your instalaltion in the field below
     #addrs:
-    #- "tyk-redis-master.tyk.svc.cluster.local:6379"
+    #   - tyk-redis-master.tyk.svc.cluster.local:6379
     # addrs:
-    #   - "redis.tyk.svc.cluster.local:6379"
+    #   - redis.tyk.svc.cluster.local:6379
     useSSL: false
     #If you're using Bitnami Redis chart please input your password in the field below
     #pass: ""
 
 mongo:
-    # mongoURL: "mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics"
+    # mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
     #If you're using Bitnami MongoDB chart please input your password below
-    #mongoURL: "mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin"
+    #mongoURL: mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin
     useSSL: false
 
 mdcb:
-  enabled: true
+  enabled: false
   useSSL: false
   replicaCount: 1
   containerPort: 9090
@@ -65,9 +68,8 @@ mdcb:
   affinity: {}
   extraEnvs: []
 
-
 tib:
-  enabled: true
+  enabled: false
   useSSL: true
   replicaCount: 1
   containerPort: 3010
@@ -82,7 +84,7 @@ tib:
     enabled: false
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/tls-acme: true
     path: /
     hosts:
       - tib.local
@@ -110,8 +112,11 @@ tib:
     profiles: tyk-tib-profiles-conf
 
 dash:
+  enabled: true
+  # Dashboard will only bootstrap if the master bootstrap option is set to true
+  bootstrap: true
   replicaCount: 1
-  hostName: "localhost"
+  hostName: tyk-dashboard.local
   license: ""
   containerPort: 3000
   image:
@@ -158,9 +163,10 @@ dash:
   org:
     name: Default Org
     # Set this value to the domain of your developer portal
-    cname: "localhost"
+    cname: tyk-portal.local
 
 portal:
+  # Portal will only bootstrap if both the Master and Dashboard bootstrap options are set to true
   # Only set this to false if you're not planning on using developer portal
   bootstrap: true
   path: /
@@ -177,20 +183,28 @@ portal:
     #      - chart-example.local
 
 gateway:
+  enabled: true
   kind: DaemonSet
   replicaCount: 2
-  hostName: "gateway.tykbeta.com"
-  tags: "ingress"
-  tls: true
+  hostName: tyk-gw.local
+  # if enableSharding set to true then you must define a tag to load APIs to these gateways i.e. "ingress"
+  tags: ""
+  tls: false
   containerPort: 8080
   image:
     repository: tykio/tyk-gateway
-    tag: v3.1.2
+    tag: v3.0.4
     pullPolicy: Always
   service:
     type: NodePort
     port: 8080
     externalTrafficPolicy: Local
+    annotations: {}
+  control:
+    enabled: true
+    containerPort: 9696
+    port: 9696
+    type: ClusterIP
     annotations: {}
   ingress:
     enabled: false
@@ -223,7 +237,8 @@ gateway:
   extraEnvs: []
 
 pump:
-  replicaCount: 2
+  enabled: true
+  replicaCount: 1
   image:
     repository: tykio/tyk-pump-docker-pub
     tag: v1.2.0

--- a/.github/tyk_pro_values.yaml
+++ b/.github/tyk_pro_values.yaml
@@ -43,7 +43,7 @@ mongo:
   useSSL: false
 
 mdcb:
-  enabled: false
+  enabled: true
   useSSL: false
   replicaCount: 1
   containerPort: 9090

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -123,7 +123,7 @@ jobs:
           elif [ "${{ matrix.directory }}" == tyk-hybrid ]; then
             helm upgrade -f ${{ env.TYK_HYBRID }} --set gateway.rpc.rpcKey=${{ secrets.HYBRID_RPC_KEY }} --set gateway.rpc.apiKey=${{ secrets.HYBRID_API_KEY }} --set gateway.rpc.connString=${{ secrets.HYBRID_MDCB_HOST }} ${{ matrix.directory }} ./${{ matrix.directory }} -n ${{ env.NAMESPACE }} --timeout ${{ env.TIMEOUT }}
           elif [ "${{ matrix.directory }}" == tyk-pro ]; then
-            helm upgrade -f ${{ env.TYK_PRO }} --set mdcb.license="${{ secrets.MDCB_LICENSE }}" --set dash.license="${{ secrets.DASH_LICENSE }}" ${{ matrix.directory }} ./${{ matrix.directory }} -n ${{ env.NAMESPACE }} --timeout ${{ env.TIMEOUT }} --wait
+            helm upgrade -f ${{ env.TYK_PRO }} --set mdcb.license="${{ secrets.MDCB_LICENSE }}" --set dash.license="${{ secrets.DASH_LICENSE }}" ${{ matrix.directory }} ./${{ matrix.directory }} -n ${{ env.NAMESPACE }} --timeout ${{ env.TIMEOUT }}
           fi
 
       - name: Uninstall "${{ matrix.directory }}" chart

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,9 +9,9 @@ on:
 env:
   TIMEOUT: 3m
   NAMESPACE: tyk-ci
-  TYK_CE: .github/tyk_ce_values.yaml 
+  TYK_CE: .github/tyk_ce_values.yaml
   TYK_PRO: .github/tyk_pro_values.yaml
-  TYK_HYBRID: .github/tyk_hybrid_values.yaml 
+  TYK_HYBRID: .github/tyk_hybrid_values.yaml
 
 jobs:
 
@@ -78,8 +78,8 @@ jobs:
           MATRIX_JSON=$(echo "$JSON" | jq --raw-output '.k8s += ["v1.20.2","v1.19.7","v1.18.15","v1.17.17","v1.16.15"]')
 
           # Set output
+          echo "::debug::matrix is ${MATRIX_JSON}"
           echo "::set-output name=matrix::$( echo $MATRIX_JSON )"
-
 
   smoke-tests:
     runs-on: ubuntu-latest
@@ -90,18 +90,18 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
-      
+
       - name: Create Kind Cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.10.0"
           config: .github/kind-cluster-${{ matrix.k8s }}.yml
-      
+
       - name: Install helm
         uses: Azure/setup-helm@v1.1
         with:
           version: v3.5.3
-      
+
       - name: Deploy "${{ matrix.directory }}" chart
         run: |
           kubectl create namespace ${{ env.NAMESPACE }}

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,3 +4,4 @@ chart-dirs:
 target-branch: master
 helm-extra-args: --timeout 8m
 check-version-increment: false
+validate-maintainers: false

--- a/tyk-headless/Chart.yaml
+++ b/tyk-headless/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Gateway, assumes that MongoDB and Redis have already been installed
 name: tyk-headless
-version: 0.8.1
+version: 0.8.2

--- a/tyk-headless/templates/_helpers.tpl
+++ b/tyk-headless/templates/_helpers.tpl
@@ -30,3 +30,11 @@ Create chart name and version as used by the chart label.
 {{- define "tyk-headless.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+Create Sematic Version of gateway without prefix v
+*/}}
+{{- define "tyk-headless.gateway-version" -}}
+{{- printf "%s" .Values.gateway.image.tag | replace "v" "" -}}
+{{- end -}}

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -48,14 +48,14 @@ spec:
       affinity:
 {{ toYaml .Values.gateway.affinity | indent 8 }}
 {{- end }}
-      initContainers: 
+      initContainers:
       - name: "setup-directories"
         image: busybox:1.32
         command: ['sh','-c','mkdir -p apps middleware policies']
         workingDir: /mnt/tyk-gateway
         volumeMounts:
           - name: tyk-scratch
-            mountPath: /mnt/tyk-gateway        
+            mountPath: /mnt/tyk-gateway
       containers:
       - name: gateway-{{ .Chart.Name }}
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
@@ -85,6 +85,8 @@ spec:
             {{- end }}
           - name: TYK_GW_STORAGE_ENABLECLUSTER
             value: "{{ default "false" .Values.redis.enableCluster }}"
+          - name: TYK_GW_STORAGE_DATABASE
+            value: "{{ default "0" .Values.redis.storage.database }}"
           - name: TYK_GW_STORAGE_PASSWORD
             value: "{{ .Values.redis.pass }}"
           - name: TYK_GW_STORAGE_USESSL

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -125,7 +125,11 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
+            {{- if and .Values.gateway.control.enabled (or (semverCompare "^3.2.x" (include "tyk-headless.gateway-version" . )) (semverCompare ">=3.0.4 < 3.1.0" (include "tyk-headless.gateway-version" .))) }}
+            port: {{ .Values.gateway.control.containerPort }}
+            {{- else }}
             port: {{ .Values.gateway.containerPort }}
+            {{- end }}
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 3
@@ -134,7 +138,11 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
+            {{- if and .Values.gateway.control.enabled (or (semverCompare "^3.2.x" (include "tyk-headless.gateway-version" . )) (semverCompare ">=3.0.4 < 3.1.0" (include "tyk-headless.gateway-version" .))) }}
+            port: {{ .Values.gateway.control.containerPort }}
+            {{- else }}
             port: {{ .Values.gateway.containerPort }}
+            {{- end }}
           initialDelaySeconds: 1
           periodSeconds: 10
           timeoutSeconds: 3

--- a/tyk-headless/values.yaml
+++ b/tyk-headless/values.yaml
@@ -10,15 +10,19 @@ secrets:
   OrgID: "1"
 
 redis:
-    shardCount: 128
-    addrs:
-      - redis.tyk.svc.cluster.local:6379
-    useSSL: false
-    #If you're using Bitnami Redis chart please input the correct host to your installation in the field below
-    #addrs:
-      #- tyk-redis-master.tyk.svc.cluster.local:6379
-    #If you're using Bitnami Redis chart please input your password in the field below
-      #pass: ""
+  shardCount: 128
+  addrs:
+    - redis.tyk.svc.cluster.local:6379
+  useSSL: false
+  # If you're using Bitnami Redis chart please input the correct host and password to your installation in the fields below
+  # addrs:
+  #  - tyk-redis-master.tyk.svc.cluster.local:6379
+  # pass: ""
+  # If you are using Redis cluster, enable it here.
+  # enableCluster: false
+  # By default the database index is 0. Setting the database index is not supported with redis cluster. As such, if you have enableCluster: true, then this value should be omitted or explicitly set to 0.
+  storage:
+    database: 0
 
 mongo:
   enabled: false
@@ -35,7 +39,7 @@ gateway:
   containerPort: 8080
   tags: ""
   image:
-    repository: tykio/tyk-gateway
+    repository: docker.tyk.io/tyk-gateway/tyk-gateway
     tag: v3.1.2
     pullPolicy: IfNotPresent
   service:
@@ -85,7 +89,7 @@ pump:
   enabled: false
   replicaCount: 1
   image:
-    repository: tykio/tyk-pump-docker-pub
+    repository: docker.tyk.io/tyk-pump/tyk-pump
     tag: v1.2.0
     pullPolicy: IfNotPresent
   annotations: {}

--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Hybrid Gateway, assumes Redis has already been installed
 name: tyk-hybrid
-version: 0.5.1
+version: 0.5.2

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -73,6 +73,8 @@ spec:
             {{- end }}
           - name: TYK_GW_STORAGE_ENABLECLUSTER
             value: "{{ default "false" .Values.redis.enableCluster }}"
+          - name: TYK_GW_STORAGE_DATABASE
+            value: "{{ default "0" .Values.redis.storage.database }}"
           - name: TYK_GW_STORAGE_PASSWORD
             value: "{{ .Values.redis.pass }}"
           - name: TYK_GW_STORAGE_USESSL
@@ -92,7 +94,7 @@ spec:
           - name: TYK_GW_SLAVEOPTIONS_BINDTOSLUGSINSTEADOFLISTENPATHS
             value: "{{ default "false" .Values.gateway.rpc.bindToSlugs }}"
           - name: TYK_GW_SLAVEOPTIONS_SSLINSECURESKIPVERIFY
-            value: "{{ .Values.gateway.rpc.sslInsecureSkipVerify }}"  
+            value: "{{ .Values.gateway.rpc.sslInsecureSkipVerify }}"
           - name: TYK_GW_DBAPPCONFOPTIONS_NODEISSEGMENTED
             value: "{{ .Values.enableSharding }}"
           - name: TYK_GW_DBAPPCONFOPTIONS_TAGS

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -12,15 +12,20 @@ secrets:
   APISecret: CHANGEME
 
 redis:
-    shardCount: 128
-    #If you're using Bitnami Redis chart please input the correct host to your instalaltion in the field below
-    #addrs:
-    #- tyk-redis-master.tyk.svc.cluster.local:6379
-    addrs:
-      - redis.tyk.svc.cluster.local:6379
-    useSSL: false
-    #If you're using Bitnami Redis chart please input your password in the field below
-    #pass: ""
+  shardCount: 128
+  addrs:
+    - redis.tyk.svc.cluster.local:6379
+  useSSL: false
+#    #If you're using Bitnami Redis chart please input the correct host to your installation in the field below
+#    addrs:
+#      - tyk-redis-master.tyk.svc.cluster.local:6379
+#   #If you're using Bitnami Redis chart please input your password in the field below
+#    pass: ""
+#   #If you are using Redis cluster, enable it here.
+#    enableCluster: false
+#   #By default the database index is 0. Setting the database index is not supported with redis cluster. As such, if you have enableCluster: true, then this value should be omitted or explicitly set to 0.
+  storage:
+    database: 0
 
 gateway:
   kind: DaemonSet

--- a/tyk-pro/Chart.yaml
+++ b/tyk-pro/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Deploys Tyk Dashboard, assumes that MongoDB and Redis have already been installed
 name: tyk-pro
-version: 0.8.1
+version: 0.8.2

--- a/tyk-pro/templates/_helpers.tpl
+++ b/tyk-pro/templates/_helpers.tpl
@@ -74,3 +74,10 @@ mongodb://{{ .Values.mongo.host }}:{{ .Values.mongo.port }}
 mongodb://mongo.{{ .Release.Namespace }}.svc.cluster.local:27017/tyk_analytics
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create Sematic Version of gateway without prefix v
+*/}}
+{{- define "tyk-pro.gateway-version" -}}
+{{- printf "%s" .Values.gateway.image.tag | replace "v" "" -}}
+{{- end -}}

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -66,15 +66,16 @@ spec:
             value: "{{ .Values.dash.hostName }}"
           - name: TYK_DB_HOSTCONFIG_GATEWAYHOSTNAME
             value: "{{ .Values.gateway.hostName }}"
-          - name: TYK_DB_TYKAPI_HOST
-            value: "{{ include "tyk-pro.gwproto" . }}://gateway-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
-          - name: TYK_DB_TYKAPI_PORT
-            value: "{{ .Values.gateway.service.port }}"
           {{- if .Values.gateway.control.enabled }}
           - name: TYK_DB_TYKAPI_HOST
             value: "{{ include "tyk-pro.gwproto" . }}://gateway-control-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
           - name: TYK_DB_TYKAPI_PORT
             value: "{{ .Values.gateway.control.containerPort }}"
+          {{- else }}
+          - name: TYK_DB_TYKAPI_HOST
+            value: "{{ include "tyk-pro.gwproto" . }}://gateway-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
+          - name: TYK_DB_TYKAPI_PORT
+            value: "{{ .Values.gateway.service.port }}"
           {{- end }}
           - name: TYK_DB_TYKAPI_SECRET
             value: "{{ .Values.secrets.APISecret }}"

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -71,9 +71,9 @@ spec:
           - name: TYK_DB_TYKAPI_PORT
             value: "{{ .Values.gateway.service.port }}"
           {{- if .Values.gateway.control.enabled }}
-          - name: TYK_GW_CONTROLAPIHOSTNAME
+          - name: TYK_DB_TYKAPI_HOST
             value: "{{ include "tyk-pro.gwproto" . }}://gateway-control-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
-          - name: TYK_GW_CONTROLAPIPORT
+          - name: TYK_DB_TYKAPI_PORT
             value: "{{ .Values.gateway.control.containerPort }}"
           {{- end }}
           - name: TYK_DB_TYKAPI_SECRET

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -71,9 +71,9 @@ spec:
           - name: TYK_DB_TYKAPI_PORT
             value: "{{ .Values.gateway.service.port }}"
           {{- if .Values.gateway.control.enabled }}
-          - name: TYK_DB_TYKAPI_HOST
+          - name: TYK_GW_CONTROLAPIHOSTNAME
             value: "{{ include "tyk-pro.gwproto" . }}://gateway-control-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
-          - name: TYK_DB_TYKAPI_PORT
+          - name: TYK_GW_CONTROLAPIPORT
             value: "{{ .Values.gateway.control.containerPort }}"
           {{- end }}
           - name: TYK_DB_TYKAPI_SECRET

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -83,6 +83,8 @@ spec:
             value: {{include "tyk-pro.redis_url" . |quote}}
           - name: TYK_GW_STORAGE_ENABLECLUSTER
             value: "{{ default "false" .Values.redis.enableCluster }}"
+          - name: TYK_GW_STORAGE_DATABASE
+            value: "{{ default "0" .Values.redis.storage.database }}"
           - name: TYK_GW_STORAGE_PASSWORD
             value: "{{ .Values.redis.pass }}"
           - name: TYK_GW_STORAGE_USESSL

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -127,7 +127,11 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
+            {{- if and .Values.gateway.control.enabled (or (semverCompare "^3.2.x" (include "tyk-pro.gateway-version" . )) (semverCompare ">=3.0.4 < 3.1.0" (include "tyk-pro.gateway-version" .))) }}
+            port: {{ .Values.gateway.control.containerPort }}
+            {{- else }}
             port: {{ .Values.gateway.containerPort }}
+            {{- end }}
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 3
@@ -136,7 +140,11 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
+            {{- if and .Values.gateway.control.enabled (or (semverCompare "^3.2.x" (include "tyk-pro.gateway-version" . )) (semverCompare ">=3.0.4 < 3.1.0" (include "tyk-pro.gateway-version" .))) }}
+            port: {{ .Values.gateway.control.containerPort }}
+            {{- else }}
             port: {{ .Values.gateway.containerPort }}
+            {{- end }}
           initialDelaySeconds: 1
           periodSeconds: 10
           timeoutSeconds: 3

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -21,21 +21,26 @@ secrets:
   AdminSecret: "12345"
 
 redis:
-    shardCount: 128
-    #If you're using Bitnami Redis chart please input the correct host to your instalaltion in the field below
-    #addrs:
-    #   - tyk-redis-master.tyk.svc.cluster.local:6379
-    # addrs:
-    #   - redis.tyk.svc.cluster.local:6379
-    useSSL: false
-    #If you're using Bitnami Redis chart please input your password in the field below
-    #pass: ""
+  shardCount: 128
+  # addrs:
+  #   - redis.tyk.svc.cluster.local:6379
+  useSSL: false
+#    #If you're using Bitnami Redis chart please input the correct host to your installation in the field below
+#    addrs:
+#      - tyk-redis-master.tyk.svc.cluster.local:6379
+#   #If you're using Bitnami Redis chart please input your password in the field below
+#    pass: ""
+#   #If you are using Redis cluster, enable it here.
+#    enableCluster: false
+#   #By default the database index is 0. Setting the database index is not supported with redis cluster. As such, if you have enableCluster: true, then this value should be omitted or explicitly set to 0.
+  storage:
+    database: 0
 
 mongo:
-    # mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
-    #If you're using Bitnami MongoDB chart please input your password below
-    #mongoURL: mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin
-    useSSL: false
+  # mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
+  # If you're using Bitnami MongoDB chart please input your password below
+  # mongoURL: mongodb://root:pass@tyk-mongo-mongodb.tyk.svc.cluster.local:27017/tyk-dashboard?authSource=admin
+  useSSL: false
 
 mdcb:
   enabled: false
@@ -46,7 +51,7 @@ mdcb:
   license: ""
   forwardAnalyticsToPump: true
   image:
-    repository: tykio/tyk-mdcb-docker #requires credential
+    repository: tykio/tyk-mdcb-docker    # requires credential
     tag: v1.7.7
     pullPolicy: Always
   service:
@@ -108,7 +113,7 @@ tib:
   affinity: {}
   extraEnvs: []
   configMap:
-    #Create a configMap to store profiles json
+    # Create a configMap to store profiles json
     profiles: tyk-tib-profiles-conf
 
 dash:
@@ -153,7 +158,7 @@ dash:
   tolerations: []
   affinity: {}
   extraEnvs: []
-  # Set these values for dashboard admin user 
+  # Set these values for dashboard admin user
   adminUser:
     firstName: admin
     lastName: user


### PR DESCRIPTION
Allow gateway liveness and readiness probe to query control-api when it's enabled. Also, the `/hello` endpoint might not be available on control api for specific versions so it checks for that and update the port accordingly. 