### PR TITLE
For future debugging

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -78,8 +78,8 @@ jobs:
           MATRIX_JSON=$(echo "$JSON" | jq --raw-output '.k8s += ["v1.20.2","v1.19.7","v1.18.15","v1.17.17","v1.16.15"]')
 
           # Set output
+          echo "::debug::matrix is ${MATRIX_JSON}"
           echo "::set-output name=matrix::$( echo $MATRIX_JSON )"
-
 
   smoke-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
You must create a secret named ACTIONS_STEP_DEBUG with the value true to see the debug messages set by this command in the log.