### PR TITLE
publish helm charts (closes #64)

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -1,0 +1,32 @@
+name: Publish Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: ./


### PR DESCRIPTION
Should fix: https://github.com/TykTechnologies/tyk-helm-chart/issues/64
Please note, the github pages should be set up for the repo, publishing from the `gh-pages` branch, as suggested in the official docs: https://github.com/marketplace/actions/helm-chart-releaser

TODO: document usage in the Readme (should be probably done once publish process is approved and working)