### PR TITLE
[BUG] Disable running actions on pro and hybrid charts for PRs

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,9 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   lint-test:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,7 +1,6 @@
 name: Smoke test
 
 on:
-  pull_request: {}
   push:
     branches:
       - master

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -1,0 +1,71 @@
+name: Smoke test and lint
+
+on:
+  pull_request: {}
+
+env:
+  TIMEOUT: 3m
+  NAMESPACE: tyk-ce
+  TYK_CE: .github/tyk_ce_values.yaml
+
+jobs:
+
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.0
+      
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
+
+  smoke-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s_version: ["v1.20.2","v1.19.7","v1.18.15","v1.17.17","v1.16.15"]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+
+      - name: Create Kind Cluster
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.11.1"
+          config: .github/kind-cluster-${{ matrix.k8s_version }}.yml
+      
+      - name: Install helm
+        uses: Azure/setup-helm@v1.1
+        with:
+          version: v3.5.3
+      
+      - name: Deploy Tyk CE and Dependencies 
+        run: |
+          kubectl create namespace ${{ env.NAMESPACE }}
+          
+          # Do not change the name
+          helm install mongo simple-mongodb --repo 'https://dl.cloudsmith.io/public/tyk/mongo-ci/helm/charts/' -n ${{ env.NAMESPACE }} --timeout ${{ env.TIMEOUT }}
+          helm install redis simple-redis --repo 'https://dl.cloudsmith.io/public/tyk/redis-ci/helm/charts/' -n ${{ env.NAMESPACE }} --timeout ${{ env.TIMEOUT }}
+
+          helm install tyk-ce ./tyk-headless -n ${{ env.NAMESPACE }} --timeout ${{ env.TIMEOUT }}
+
+      - name: Upgrade Tyk CE
+        run: |
+          helm upgrade -f ${{ env.TYK_CE }} tyk-ce ./tyk-headless -n ${{ env.NAMESPACE }} --timeout ${{ env.TIMEOUT }}
+
+      - name: Uninstall Tyk CE
+        run: |
+          helm uninstall tyk-ce -n ${{ env.NAMESPACE }} --timeout ${{ env.TIMEOUT }}


### PR DESCRIPTION
Due to the limitation in #126, this PR allows to run smoke tests on Tyk Headless chart and lint all charts for every PR coming from branches or forks. Once we resolve on how to share secrets with workflows from forks, we can revert these changes.

Also, smoke tests and lint will run for all charts on master branch once PR is merged.  