### PR TITLE
[BUG] Fix broken smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  TIMEOUT: 5m
+  TIMEOUT: 8m
   NAMESPACE: tyk-ci
   TYK_CE: .github/tyk_ce_values.yaml
   TYK_PRO: .github/tyk_pro_values.yaml


### PR DESCRIPTION
After merging #138, smoke tests on tyk-pro chart are failing on master due to dashboard pod is taking more than allocated time to reach ready status. I've bumped the timeout, which should fix the broken tests.