### PR TITLE
Update instructions and appVersion

### DIFF
--- a/tyk-headless/Chart.yaml
+++ b/tyk-headless/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.0"
 name: tyk-headless
+appVersion: "v3.2.1"
 version: 0.9.1
 icon: https://tyk.io/wp-content/uploads/2021/07/tyk_logo_bg.jpg
 home: https://tyk.io/
@@ -17,7 +17,7 @@ keywords:
   - open source gateway
   - edge gateway
 description: |-
-  This chart deploys the open source Tyk Gateway. It assumes Redis has already been installed.
-  Tyk is an open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
-  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. Enabling your organization to control who accesses your APIs, when they access, and how they access it.
-  Tyk Technologies uses the same API Gateway for all it’s applications. Protecting, securing, and processing APIs for thousands of organizations and businesses around the world.
+  This chart deploys the open source Tyk Gateway.
+  Tyk Gateway is a fully open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
+  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organizations and businesses around
+  the world to protecte, secure, and processe APIs and well as review and audit the consumed apis.

--- a/tyk-headless/Chart.yaml
+++ b/tyk-headless/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 name: tyk-headless
-appVersion: "v3.2.1"
 version: 0.9.1
 icon: https://tyk.io/wp-content/uploads/2021/07/tyk_logo_bg.jpg
 home: https://tyk.io/

--- a/tyk-headless/Chart.yaml
+++ b/tyk-headless/Chart.yaml
@@ -19,5 +19,5 @@ keywords:
 description: |-
   This chart deploys the open source Tyk Gateway.
   Tyk Gateway is a fully open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
-  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organizations and businesses around
-  the world to protecte, secure, and processe APIs and well as review and audit the consumed apis.
+  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organisations and businesses around
+  the world to protect, secure, and process APIs and well as review and audit the consumed apis.

--- a/tyk-headless/README.md
+++ b/tyk-headless/README.md
@@ -1,7 +1,21 @@
-## Tyk Community Edition
-Provides a Tyk Installation for Community Edition Gateways
+## Tyk OSS Gateway
+This chart deploys the open source Tyk Gateway.
+
+---
+
+[Installation](https://tyk.io/docs/apim/open-source/installation/) || [Documentation](https://tyk.io/docs) || [Community Forum](https://community.tyk.io/) || [Releases](https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&ordering=last_updated)
+
+---
+
+## Prerequisites
+Redis should already be installed or accessible by the gateway.
+
+Check [Tyk OSS Helm chart Installation](https://tyk.io/docs/tyk-oss/ce-helm-chart/) for the full details.
 
 ## Installation
+
 	helm repo add tyk-helm https://helm.tyk.io/public/helm/charts/
 	helm repo update
+	kubectl create namespace tyk
 	helm install tyk-ce tyk-helm/tyk-headless --version 0.9.1 -n tyk
+

--- a/tyk-headless/README.md
+++ b/tyk-headless/README.md
@@ -17,5 +17,5 @@ Check [Tyk OSS Helm chart Installation](https://tyk.io/docs/tyk-oss/ce-helm-char
 	helm repo add tyk-helm https://helm.tyk.io/public/helm/charts/
 	helm repo update
 	kubectl create namespace tyk
-	helm install tyk-ce tyk-helm/tyk-headless --version 0.9.1 -n tyk
+	helm install tyk-ce tyk-helm/tyk-headless --version 0.9.1 -n tyk --create-namespace
 

--- a/tyk-headless/templates/_helpers.tpl
+++ b/tyk-headless/templates/_helpers.tpl
@@ -31,7 +31,7 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- /* Create Sematic Version of gateway without prefix v */}}
+{{- /* Create Semantic Version of gateway without prefix v */}}
 {{- define "tyk-headless.gateway-version" -}}
 {{- printf "%s" .Values.gateway.image.tag | replace "v" "" -}}
 {{- end -}}

--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -19,5 +19,5 @@ keywords:
 description: |-
   This chart deploys the open source Tyk Gateway with an Hybrid setup that connects to a management control plane.
   Tyk is a fully open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
-  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organizations and businesses around
-  the world to protecte, secure, and processe APIs and well as review and audit the consumed apis.
+  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organisations and businesses around
+  the world to protect, secure, and process APIs and well as review and audit the consumed apis.

--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.0"
 name: tyk-hybrid
+appVersion: "v3.2.1"
 version: 0.9.1
 icon: https://tyk.io/wp-content/uploads/2021/07/tyk_logo_bg.jpg
 home: https://tyk.io/
@@ -17,7 +17,7 @@ keywords:
   - open source gateway
   - edge gateway
 description: |-
-  This chart deploys the open source Tyk Gateway. It assumes Redis has already been installed.
-  Tyk is an open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
-  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. Enabling your organization to control who accesses your APIs, when they access, and how they access it.
-  Tyk Technologies uses the same API Gateway for all it’s applications, protecting, securing, and processing APIs for thousands of organizations and businesses around the world.
+  This chart deploys the open source Tyk Gateway with an Hybrid setup that connects to a management control plane.
+  Tyk is a fully open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
+  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organizations and businesses around
+  the world to protecte, secure, and processe APIs and well as review and audit the consumed apis.

--- a/tyk-hybrid/Chart.yaml
+++ b/tyk-hybrid/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 name: tyk-hybrid
-appVersion: "v3.2.1"
 version: 0.9.1
 icon: https://tyk.io/wp-content/uploads/2021/07/tyk_logo_bg.jpg
 home: https://tyk.io/

--- a/tyk-hybrid/README.md
+++ b/tyk-hybrid/README.md
@@ -1,16 +1,25 @@
 ## Tyk Hybrid
 Provides a Tyk Installation for Hybrid Gateways connected to Tyk Cloud or MDCB Hybrid Gateways
 
+[Installation](https://tyk.io/docs/apim/open-source/installation/) || [Documentation](https://tyk.io/docs) || [Community Forum](https://community.tyk.io/) || [Releases](https://hub.docker.com/r/tykio/tyk-gateway/tags?page=1&ordering=last_updated)
+
+---
+
+## Prerequisites
+Redis should already be installed or accessible by the gateway.
+
+Check [Tyk Hybrid Helm chart Installation](https://tyk.io/docs/tyk-cloud/environments-deployments/hybrid-gateways/#installing-hybrid-gateways-in-a-kubernetes-cluster) for the full details.
+
 ### Installation
-```
-helm repo add tyk-helm https://helm.tyk.io/public/helm/charts/
-helm repo update
-```
+
+    helm repo add tyk-helm https://helm.tyk.io/public/helm/charts/
+    helm repo update
+
 
 Before we proceed with installation of the chart we need to set some custom values. To see what options are configurable on a chart and save that options to a custom values.yaml file run:
-```
-helm show values tyk-helm/tyk-hybrid > values.yaml
-```
+
+   helm show values tyk-helm/tyk-hybrid > values.yaml
+
 
 *For Tyk-hybrid chart we need to modify following values in your custom values.yaml file:*
 1. Add your dashboard users organisation ID in `gateway.rpc.rpcKey` value
@@ -18,7 +27,7 @@ helm show values tyk-helm/tyk-hybrid > values.yaml
 3. Add your connection string to allow the Hybrid gateway to connect to your control plane in `gateway.rpc.connString`. On the Tyk Cloud Console find this value in the endpoints panel for your control plane deployment.
 
 Then we can install the chart using our custom values file:
-```
-helm install tyk-hybrid tyk-helm/tyk-hybrid --version 0.9.1 -f values.yaml -n tyk
-```
+
+    helm install tyk-hybrid tyk-helm/tyk-hybrid --version 0.9.1 -f values.yaml -n tyk
+
 > If you are using hybrid gateway with the Tyk Classic Cloud use the rpc settings block commented out in the `values.yaml`

--- a/tyk-hybrid/README.md
+++ b/tyk-hybrid/README.md
@@ -28,6 +28,6 @@ Before we proceed with installation of the chart we need to set some custom valu
 
 Then we can install the chart using our custom values file:
 
-    helm install tyk-hybrid tyk-helm/tyk-hybrid --version 0.9.1 -f values.yaml -n tyk
+    helm install tyk-hybrid tyk-helm/tyk-hybrid --version 0.9.1 -f values.yaml -n tyk --create-namespace
 
 > If you are using hybrid gateway with the Tyk Classic Cloud use the rpc settings block commented out in the `values.yaml`

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -55,7 +55,7 @@ gateway:
   # Also be sure to match API segmentation tags with the tags selected below.
   sharding:
     enabled: false
-    tag: ""
+    tags: ""
   # When true, sets the gateway protocol to HTTPS.
   tls: false
   # For on premise MDCB setups simply change the connection string to point to

--- a/tyk-pro/Chart.yaml
+++ b/tyk-pro/Chart.yaml
@@ -19,5 +19,5 @@ keywords:
 description: |-
   This chart deploys full Tyk platform.
   Tyk Gateway is a fully open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
-  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organizations and businesses around
-  the world to protecte, secure, and processe APIs and well as review and audit the consumed apis.
+  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organisations and businesses around
+  the world to protect, secure, and process APIs and well as review and audit the consumed apis.

--- a/tyk-pro/Chart.yaml
+++ b/tyk-pro/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 name: tyk-pro
-appVersion: "v3.2.1"
 version: 0.9.1
 icon: https://tyk.io/wp-content/uploads/2021/07/tyk_logo_bg.jpg
 home: https://tyk.io/

--- a/tyk-pro/Chart.yaml
+++ b/tyk-pro/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.0"
 name: tyk-pro
+appVersion: "v3.2.1"
 version: 0.9.1
 icon: https://tyk.io/wp-content/uploads/2021/07/tyk_logo_bg.jpg
 home: https://tyk.io/
@@ -17,8 +17,7 @@ keywords:
   - open source gateway
   - edge gateway
 description: |-
-  This chart deploys Tyk platform including Tyk Manager (Tyk dashboard), Tyk Gateway, Tyk pump and MDCB (Multi Data-centre Bridge).
-  It assumes Mongo and Redis have already been installed.
-  Tyk platform includes an open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
-  Tyk provides you with all the analytics you need - view your data through the Tyk Manager, then export it to any BI tool with Tyk Pump.
-  With the right data to hand, you have the power to make the right business and investment decisions.
+  This chart deploys full Tyk platform.
+  Tyk Gateway is a fully open source Enterprise API Gateway, supporting REST, GraphQL, TCP and gRPC protocols.
+  Tyk Gateway is provided ‘Batteries-included’, with no feature lockout. It enables organizations and businesses around
+  the world to protecte, secure, and processe APIs and well as review and audit the consumed apis.

--- a/tyk-pro/README.md
+++ b/tyk-pro/README.md
@@ -23,12 +23,18 @@ To see what options are configurable on a chart and save that options to a custo
 
     helm show values tyk-helm/tyk-pro > values.yaml
 
-For *Tyk Self-managed* chart we need to set the license key in your custom `values.yaml` file under `dash.license` 
-field or use `--set dash.license={YOUR-LICENSE_KEY}` with the helm install command.
+For *Tyk Self-managed* chart we need to set the following in `values.yaml` or with `--set {field-name}={field-value}`with the helm install command:
+
+|  | Description             | Field name          |
+|--|-------------------------|---------------------|
+|1.| License key             | `dash.license`      |
+|2.| Mongodb root password   | in `mongo.mongoURL` |
+|3.| Redis password          | `redis.pass`        |
+
 
 Then we can install the chart using our custom values:
 
-    helm install tyk-pro tyk-helm/tyk-pro --version 0.9.1 -f values.yaml -n tyk --wait
+    helm install tyk-pro tyk-helm/tyk-pro --version 0.9.1 -f values.yaml -n tyk --create-namespace --wait
 
 > Please note the --wait argument is important for successful dashboard bootstrap.
 

--- a/tyk-pro/README.md
+++ b/tyk-pro/README.md
@@ -1,55 +1,41 @@
-## Tyk Pro
-Provides a full Tyk Installation API Management Dashboard and API Gateways with Analytics)
+## Tyk Self-managed
+This chart provides a full Tyk API Management platform including Tyk Manager (Tyk dashboard), Tyk Gateway (OSS), Tyk pump 
+and MDCB (Multi Data-centre Bridge).
+
+---
+
+[Installation](https://tyk.io/docs/apim/open-source/installation/) || [Documentation](https://tyk.io/docs) || [Community Forum](https://community.tyk.io/)
+
+---
+
+## Prerequisites
+Redis and MongoDB should already be installed or accessible by the gateway.
+
+Check [Tyk Self-managed Helm chart Installation](https://tyk.io/docs/tyk-self-managed/tyk-helm-chart/) for the full details.
 
 ### Installation
-```
-helm repo add tyk-helm https://helm.tyk.io/public/helm/charts/
-helm repo update
-```
-Before we proceed with installation of the chart we need to set some custom values. To see what options are configurable on a chart and save that options to a custom values.yaml file run:
-```
-helm show values tyk-helm/tyk-pro > values.yaml
-```
-*For Tyk-pro chart we need to modify following value in your custom values.yaml file:*
-1. Add your dashboard license in `dash.license` value
+
+    helm repo add tyk-helm https://helm.tyk.io/public/helm/charts/
+    helm repo update
+
+Before we proceed with installation of the chart we need to set some custom values. 
+To see what options are configurable on a chart and save that options to a custom values.yaml file run:
+
+    helm show values tyk-helm/tyk-pro > values.yaml
+
+For *Tyk Self-managed* chart we need to set the license key in your custom `values.yaml` file under `dash.license` 
+field or use `--set dash.license={YOUR-LICENSE_KEY}` with the helm install command.
 
 Then we can install the chart using our custom values:
-```
-helm install tyk-pro tyk-helm/tyk-pro --version 0.9.1 -f values.yaml -n tyk --wait
-```
+
+    helm install tyk-pro tyk-helm/tyk-pro --version 0.9.1 -f values.yaml -n tyk --wait
+
 > Please note the --wait argument is important for successful dashboard bootstrap.
 
 Follow the instructions in the Notes that follow the installation to find your Tyk login credentials.
 
-### Tyk Developer Portal
-You can disable the bootstrapping of the Developer Portal using the `portal.bootstrap` option in `values.yaml`.
-
-## Installing TIB
-TIB is not necessary to install for this chart as it's functionality is included in the Tyk Dashboard API Manager. However, if you want to run it separately from the Dashboard you can do so.
-
-The Tyk Identity Broker (TIB) is a micro-service portal that provides a bridge between various Identity Management Systems such as LDAP, Social OAuth (e.g. GPlus, Twitter, GitHub), legacy Basic Authentication providers, to your Tyk installation (https://tyk.io/docs/getting-started/tyk-components/identity-broker/).
-
-Once you have installed the `Gateway` and `Dashboard` components you can configure TIB by adding its configuration environment variables under the `tib.extraEnvs` section  and updating the `profile.json` under the configs folder, you can read about how to configure them here https://github.com/TykTechnologies/tyk-identity-broker#how-to-configure-tib. Once you complete your modifications you can run the following command to update the helm chart if you had already installed it:
-```
-helm upgrade tyk-pro tyk-helm/tyk-pro -n tyk
-```
-This chart implies there's a ConfigMap with a `profiles.json` definition in it. Please use `tib.configMap.profiles` value to set the name of this ConfigMap (`tyk-tib-profiles-conf` by default).
-
-## Installing MDCB
-If you are deploying the Master Data Centre in an MDCB deployment then you can set the `mdcb.enabled` option in the `values.yaml` to `true` to add of the MDCB component to your installation. For more details about the MDCB component see here https://tyk.io/docs/tyk-multi-data-centre/
-
-This enables multi cluster, multi Data-Centre API management from a single Dashboard.
-
-**Secrets**
-The Tyk owned MDCB registry is private and requires adding users to our organisation which you then define as a secret when pulling the MDCB image. Please contact your account manager to arrange this.
-
-## Caveat: Tyk license and the number of gateway nodes
-Different Tyk Pro Licenses allow for different numbers of Gateway nodes to connect to a single Dashboard instance - ensure that your Gateway pods will not scale beyond this number by setting the gateway resource kind to `Deployment` and setting the replica count to the node limit. For example, use the following options for a single node license: `--set gateway.kind=Deployment --set gateway.replicaCount=1` or similar if modifying the `values.yaml`.
-
-Note, however, there may be intermittent issues on the new pods during the rolling update process, when the total number of online gateway pods is more than the license limit with lower amounts of Licensed nodes.
-
-## Sharding
-Sharding is adding the ability for you to decide which of your APIs are loaded on which gateways. This option is turned off by default, however, you can turn it on by updating the `gateway.sharding.enabled` option. Once you do that you will need to also populate the `gateway.sharding.tags` value which the tags that you want that gateway to load. (ex. tags: "external,ingress".) You can then add those tags to your APIs in the API Designer, under the "Advanced Options" tab, and `Segment Tags (Node Segmentation)` section in the dashboard.
-
-## Istio Service Mesh Ingress gateway
-To use Tyks gateways as the ingress to your Istio Service Mesh simply change `gateway.enableIstioIngress: true` in the values.yaml. Ensure you are using an Istio manifest which disables the default Istio Ingress gateway.
+### Other component 
+Please refer to Tyk official docs for details about installation and setting [*TIB*](https://tyk.io/docs/tyk-self-managed/tyk-helm-chart/#tyk-identity-broker-tib), 
+[*Tyk Developer portal*](https://tyk.io/docs/tyk-self-managed/tyk-helm-chart/#tyk-developer-portal), 
+[*MDCB*](https://tyk.io/docs/tyk-self-managed/tyk-helm-chart/#installing-tyk-self-managed-control-plane) and
+[*Istio*](https://tyk.io/docs/tyk-self-managed/istio/).

--- a/tyk-pro/templates/_helpers.tpl
+++ b/tyk-pro/templates/_helpers.tpl
@@ -77,7 +77,7 @@ mongodb://mongo.{{ .Release.Namespace }}.svc.cluster.local:27017/tyk_analytics
 {{- end -}}
 {{- end -}}
 
-{{- /* Create Sematic Version of gateway without prefix v */}}
+{{- /* Create Semantic Version of gateway without prefix v */}}
 {{- define "tyk-pro.gateway-version" -}}
 {{- printf "%s" .Values.gateway.image.tag | replace "v" "" -}}
 {{- end -}}

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+
+    # Removed the use of appVersion since it's not accurate. We'll put it back in v1.0
+    # when every app will have its own a chart
+    # app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     # This is what defines this resource as a hook. Without this line, the

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -56,7 +56,7 @@ redis:
   storage:
     database: 0
 
-mongo: {}
+mongo:
   # The mongoURL value will allow you to set your MongoDB address.
   # Default value: mongodb://mongo.{{ .Release.Namespace }}.svc.cluster.local:27017/tyk_analytics
   # mongoURL: mongodb://mongo.tyk.svc.cluster.local:27017/tyk_analytics
@@ -66,7 +66,7 @@ mongo: {}
 
   # Enables SSL for MongoDB connection. MongoDB instance will have to support that.
   # Default value: false
-  # useSSL: true
+  useSSL: false
 
 mdcb:
   # Determines whither or not the mdcb component should be installed.

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -269,7 +269,7 @@ gateway:
   # Also be sure to match API segmentation tags with the tags selected below.
   sharding:
     enabled: false
-    tag: ""
+    tags: ""
   # Set to true to use Tyk as the Ingress gateway to an Istio Service Mesh
   # We apply some exceptions to the Istio IPTables so inbound calls to the
   # Gateway and Dashboard are exposed to the outside world - see the deployment


### PR DESCRIPTION
1. add appVersion
2. remove the `mongo: {}` in tyk-pro/values.yaml since it's confusing. If you set the mongoURL because of the few comment lines you don't see that there're `{}` after `mongo` that needs to be deleted. Adding a single field with the default value sort this out
3. Wrong field name. We had "tag" for sharding the gateways instead of "tags". I tested it by copying the gateway section in values.yaml and deployment and service and saw that with "tags it works.