### PR TITLE
Change tyk hybrid command to use the local config file isntead of def…

### DIFF
--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -128,7 +128,7 @@ spec:
             value: {{ $env.value | quote }}
         {{- end }}
         {{- end }}
-        command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
+        command: ["/opt/tyk-gateway/tyk", "--conf=/opt/tyk-gateway/tyk.conf"]
         workingDir: /opt/tyk-gateway
         ports:
         - containerPort: {{ .Values.gateway.containerPort }}


### PR DESCRIPTION
k8s hybrid deployment is not using the file that is being mounted at all.  the config file is mounted to opt/tyk-gateway and the gateway is using /etc/tyk-gateway

```
        command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
```