### PR TITLE
chore: add parameterizable nodePort for gateway and dashboard

### DIFF
--- a/tyk-pro/README.md
+++ b/tyk-pro/README.md
@@ -45,3 +45,28 @@ Please refer to Tyk official docs for details about installation and setting [*T
 [*Tyk Developer portal*](https://tyk.io/docs/tyk-self-managed/tyk-helm-chart/#tyk-developer-portal),
 [*MDCB*](https://tyk.io/docs/tyk-self-managed/tyk-helm-chart/#installing-tyk-self-managed-control-plane) and
 [*Istio*](https://tyk.io/docs/tyk-self-managed/istio/).
+
+### Kind as local k8s cluster
+If you decide to use [*KIND*](https://kind.sigs.k8s.io/) as local k8s cluster you can rely on the following configuration in order to reach Tyk Gateway and Tyk Dashboard:
+
+    cat << EOF > kind-config.yaml
+    kind: Cluster
+    name: tyk-pro-cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+    - role: control-plane
+      extraPortMappings:
+      - containerPort: 30001
+        hostPort: 3000
+        listenAddress: "0.0.0.0"
+        protocol: TCP
+      - containerPort: 30002
+        hostPort: 8080
+        listenAddress: "0.0.0.0"
+        protocol: TCP
+    EOF
+
+When creating the cluster please specify the config file as following:
+    kind create cluster --config=kind-config.yaml
+
+Then you can access *Tyk-Gateway* on http://localhost:13000 and *Tyk-Dashboard* on http://localhost:18080

--- a/tyk-pro/templates/service-dash.yaml
+++ b/tyk-pro/templates/service-dash.yaml
@@ -12,6 +12,9 @@ spec:
   ports:
   - port: {{ .Values.dash.service.port }}
     targetPort: {{ .Values.dash.containerPort }}
+    {{- if .Values.dash.service.nodePort }}
+    nodePort: {{ .Values.dash.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   type: {{ .Values.dash.service.type }}

--- a/tyk-pro/templates/service-gw.yaml
+++ b/tyk-pro/templates/service-gw.yaml
@@ -19,6 +19,9 @@ spec:
   ports:
   - port: {{ .Values.gateway.service.port }}
     targetPort: {{ .Values.gateway.containerPort }}
+    {{- if .Values.gateway.service.nodePort }}
+    nodePort: {{ .Values.gateway.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -213,6 +213,7 @@ dash:
   service:
     type: NodePort
     port: 3000
+    nodePort: 30001
   # Creates an ingress object in k8s. Will require an ingress-controller and
   # annotation to that ingress controller.
   ingress:
@@ -294,6 +295,7 @@ gateway:
   service:
     type: NodePort
     port: 8080
+    nodePort: 30002
     externalTrafficPolicy: Local
     annotations: {}
   control:


### PR DESCRIPTION
I found this changes useful while deploying tyk-pro using KIND. I also added small piece of readme for guidance purposes on how to configure kind for reaching the nodePorts.