### PR TITLE
tyk-headless: add service port name to fix ingress issue

### DIFF
--- a/tyk-headless/templates/service-gw.yaml
+++ b/tyk-headless/templates/service-gw.yaml
@@ -19,6 +19,7 @@ spec:
   - port: {{ .Values.gateway.service.port }}
     targetPort: {{ .Values.gateway.containerPort }}
     protocol: TCP
+    name: http
   selector:
     app: gateway-{{ include "tyk-headless.fullname" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
the ingress-gw.yaml file use 'servicePort: http' to config service port, so need to add service port name in 'service' config