### PR TITLE
making user passed secrets mount in main container

### DIFF
--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -59,13 +59,7 @@ spec:
         workingDir: /mnt/tyk-gateway
         volumeMounts:
           - name: tyk-scratch
-            mountPath: /mnt/tyk-gateway
-          {{- if .Values.gateway.mounts }}
-          {{- range $secret := .Values.gateway.mounts }}
-          - name: {{ $.Release.Name }}-gateway-secret-{{ $secret.name }}
-            mountPath: {{ $secret.mountPath }}
-          {{- end }}
-          {{- end }}
+            mountPath: /mnt/tyk-gateway   
       containers:
       - name: gateway-{{ .Chart.Name }}
         image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
@@ -139,6 +133,12 @@ spec:
             mountPath: /etc/certs
           - name: tyk-scratch
             mountPath: /mnt/tyk-gateway
+          {{- if .Values.gateway.mounts }}
+          {{- range $secret := .Values.gateway.mounts }}
+          - name: {{ $.Release.Name }}-gateway-secret-{{ $secret.name }}
+            mountPath: {{ $secret.mountPath }}
+          {{- end }}
+          {{- end }}
         livenessProbe:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"


### PR DESCRIPTION
Making this minor change, so that the user passing mount values from values.yaml file will be correctly mounted under the main container rather the initContainer since it goes off once the main container is initialized and the mounted secret becomes null.