### PR TITLE
optimize storage redis configuration to support different mode

### DIFF
--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -84,8 +84,23 @@ spec:
             value: "128"
           - name: TYK_GW_STORAGE_ADDRS
             value: {{ include "tyk-headless.redis_url" . | quote }}
+          {{ if .Values.redis.enableSentinel }}
+          - name: TYK_GW_STORAGE_SENTINELPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-headless.fullname" . }} {{ end }}
+                key: redisSentinelPass
+          - name: TYK_GW_STORAGE_MASTERNAME
+            value: "{{- .Values.redis.masterName -}}"
+         {{ else if .Values.redis.enableCluster }}
           - name: TYK_GW_STORAGE_ENABLECLUSTER
-            value: "{{ default "false" .Values.redis.enableCluster }}"
+            value: "true"
+         {{ else }}
+          - name: TYK_GW_STORAGE_MASTERNAME
+            value: ""
+          - name: TYK_GW_STORAGE_ENABLECLUSTER
+            value: "false"
+         {{ end }}
           - name: TYK_GW_STORAGE_DATABASE
             value: "{{ default "0" .Values.redis.storage.database }}"
           - name: TYK_GW_STORAGE_PASSWORD

--- a/tyk-headless/templates/deployment-pmp.yaml
+++ b/tyk-headless/templates/deployment-pmp.yaml
@@ -70,8 +70,23 @@ spec:
             {{- else }}
             value: "{{ join "," .Values.redis.addrs }}"
             {{- end }}
+          {{ if .Values.redis.enableSentinel }}
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_SENTINELPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-headless.fullname" . }} {{ end }}
+                key: redisSentinelPass
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_MASTERNAME
+            value: "{{- .Values.redis.masterName -}}"
+          {{ else if .Values.redis.enableCluster }}
           - name: TYK_PMP_ANALYTICSSTORAGECONFIG_ENABLECLUSTER
-            value: "{{ default "false" .Values.redis.enableCluster }}"
+            value: "true"
+          {{ else }}
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_MASTERNAME
+            value: ""
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_ENABLECLUSTER
+            value: "false"
+          {{ end }}
           - name: TYK_PMP_ANALYTICSSTORAGECONFIG_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/tyk-headless/templates/secrets.yaml
+++ b/tyk-headless/templates/secrets.yaml
@@ -11,6 +11,7 @@ metadata:
 type: Opaque
 stringData:
   redisPass: "{{ .Values.redis.pass }}"
+  redisSentinelPass: "{{ .Values.redis.sentinelPass }}"
   mongoURL: {{ include "tyk-headless.mongo_url" . | quote }}
   APISecret: "{{ .Values.secrets.APISecret }}"
 {{- end }}

--- a/tyk-headless/values.yaml
+++ b/tyk-headless/values.yaml
@@ -41,10 +41,18 @@ redis:
   # Default value: false
   # useSSL: true
 
-  # The enableCluster value will allow you to indicate to Tyk whither you are
+  # The enableCluster value will allow you to indicate to Tyk whether you are
   # running a Redis cluster or not.
-  # Default value: false
   # enableCluster: true
+
+  # Enables sentinel connection mode for Redis. If enabled, sentinelPass and masterName values are required.
+  # enableSentinel: false
+
+  # Redis sentinel password, only required while enableSentinel is true.
+  # sentinelPass: ""
+
+  # Redis sentinel master name, only required while enableSentinel is true.
+  # masterName: ""
 
   # By default the database index is 0. Setting the database index is not
   # supported with redis cluster. As such, if you have enableCluster: true,


### PR DESCRIPTION
According to `NewRedisClusterPool`, different storage redis configuration will initialize different redis client:

* master_name != "", redis client will be `redis.NewFailoverClient`
* enable_cluster == true, redis client will be `redis.NewClusterClient`
* others condition, redis client will be `redis.NewClient`

Signed-off-by: Chenyang Yan <memory.yancy@gmail.com>

P.S.: if it's significant, I will also update `tyk-hybrid, tyk-pro` similar Redis configuration and rebase commit :smiley:.

CC: @kulong0105 