### PR TITLE
[TT-4979] added group_id to hybrid chart

### DIFF
--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -108,6 +108,10 @@ spec:
             value: "{{ default "false" .Values.gateway.rpc.bindToSlugs }}"
           - name: TYK_GW_SLAVEOPTIONS_SSLINSECURESKIPVERIFY
             value: "{{ .Values.gateway.rpc.sslInsecureSkipVerify }}"
+        {{- if .Values.gateway.rpc.groupId }}
+          - name: TYK_GW_SLAVEOPTIONS_GROUPID
+            value: "{{ .Values.gateway.rpc.groupId }}"
+        {{- end }}
         # Enable backward compatibility to chart 0.5.1.
         {{- if or .Values.gateway.sharding .Values.enableSharding}}
           - name: TYK_GW_DBAPPCONFOPTIONS_NODEISSEGMENTED

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -76,6 +76,11 @@ gateway:
     rpcKey: ""
     # API key of your dashboard user
     apiKey: ""
+    # Group/cluster that this instance belongs.
+    # Required when running multiple isolated clusters each having their own Redis instance.
+    # Must be the same across all the gateways of a cluster which share a Redis.
+    # Must be unique per cluster.
+    groupId: ""
     #
     # For a classic cloud hybrid gateway use these settings:
     #


### PR DESCRIPTION
Updated tyk-hybrid chart to support running multiple isolated gateway clusters using group_id, and fixes issue [193](https://github.com/TykTechnologies/tyk-helm-chart/issues/193)