### PR TITLE
[TT-5524] Update bootstrap post-install hook and introduce new field in the values.yaml

### DIFF
--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -167,17 +167,6 @@ kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
   --from-literal "TYK_ORG=${ORGID}" \
   --from-literal "TYK_MODE=pro" \
   --from-literal "TYK_URL=${DASHBOARD_HOSTNAME}"
-else
-  echo "Operator secret can be created as follows:"
-  echo "kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
-
-	  --from-literal \"TYK_AUTH=${USER_AUTH_CODE}\" \
-
-	  --from-literal \"TYK_ORG=${ORGID}\" \
-
-	  --from-literal \"TYK_MODE=pro\" \
-
-	  --from-literal \"TYK_URL=${DASHBOARD_HOSTNAME}\""
 fi
 
 if [ "$DASHBOARD_ENABLED" = "true" ]

--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -162,15 +162,15 @@ fi
 
 if [ "$OPERATOR_SECRET_ENABLED" = "true" ] && [ "$BOOTSTRAP_DASHBOARD" = "true" ]
 then
-  kubectl get secrets -n ${TYK_POD_NAMESPACE} tyk-operator-conf || operator_secret_exists=$?
+  kubectl get secrets -n "$TYK_POD_NAMESPACE" "$OPERATOR_SECRET_NAME" || operator_secret_exists=$?
 
-  # if tyk-operator-conf exists, delete the previous secret. 
+  # if $OPERATOR_SECRET_NAME exists, delete the previous secret.
   if [[ $operator_secret_exists -eq 0 ]]
   then
-    kubectl delete secret -n ${TYK_POD_NAMESPACE} tyk-operator-conf
+    kubectl delete secret -n "$TYK_POD_NAMESPACE" "$OPERATOR_SECRET_NAME"
   fi
   
-  kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
+  kubectl create secret -n "$TYK_POD_NAMESPACE" generic "$OPERATOR_SECRET_NAME" \
     --from-literal "TYK_AUTH=${USER_AUTH_CODE}" \
     --from-literal "TYK_ORG=${ORGID}" \
     --from-literal "TYK_MODE=pro" \

--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -162,11 +162,19 @@ fi
 
 if [ "$OPERATOR_SECRET_ENABLED" = "true" ] && [ "$BOOTSTRAP_DASHBOARD" = "true" ]
 then
-kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
-  --from-literal "TYK_AUTH=${USER_AUTH_CODE}" \
-  --from-literal "TYK_ORG=${ORGID}" \
-  --from-literal "TYK_MODE=pro" \
-  --from-literal "TYK_URL=${DASHBOARD_HOSTNAME}"
+  kubectl get secrets -n ${TYK_POD_NAMESPACE} tyk-operator-conf || operator_secret_exists=$?
+
+  # if tyk-operator-conf exists, delete the previous secret. 
+  if [[ $operator_secret_exists -eq 0 ]]
+  then
+    kubectl delete secret -n ${TYK_POD_NAMESPACE} tyk-operator-conf
+  fi
+  
+  kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
+    --from-literal "TYK_AUTH=${USER_AUTH_CODE}" \
+    --from-literal "TYK_ORG=${ORGID}" \
+    --from-literal "TYK_MODE=pro" \
+    --from-literal "TYK_URL=${DASHBOARD_HOSTNAME}"
 fi
 
 if [ "$DASHBOARD_ENABLED" = "true" ]

--- a/tyk-pro/scripts/bootstrap.sh
+++ b/tyk-pro/scripts/bootstrap.sh
@@ -160,11 +160,25 @@ then
   main $DASHBOARD_HOSTNAME
 fi
 
+if [ "$OPERATOR_SECRET_ENABLED" = "true" ] && [ "$BOOTSTRAP_DASHBOARD" = "true" ]
+then
 kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
   --from-literal "TYK_AUTH=${USER_AUTH_CODE}" \
   --from-literal "TYK_ORG=${ORGID}" \
   --from-literal "TYK_MODE=pro" \
   --from-literal "TYK_URL=${DASHBOARD_HOSTNAME}"
+else
+  echo "Operator secret can be created as follows:"
+  echo "kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
+
+	  --from-literal \"TYK_AUTH=${USER_AUTH_CODE}\" \
+
+	  --from-literal \"TYK_ORG=${ORGID}\" \
+
+	  --from-literal \"TYK_MODE=pro\" \
+
+	  --from-literal \"TYK_URL=${DASHBOARD_HOSTNAME}\""
+fi
 
 if [ "$DASHBOARD_ENABLED" = "true" ]
 then

--- a/tyk-pro/scripts/init.sh
+++ b/tyk-pro/scripts/init.sh
@@ -6,6 +6,7 @@ apk --no-cache add curl jq
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-echo "waiting for dashboard to be ready"
-while [[ $(kubectl get pod -n $TYK_POD_NAMESPACE -l app=$TYK_DASHBOARD_DEPLOY -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do sleep 10; done && \
+while [[ $(kubectl get pod -n $TYK_POD_NAMESPACE -l app=$TYK_DASHBOARD_DEPLOY -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; 
+    do echo "Waiting for Dashboard pod to be ready" && sleep 10; 
+done && \
 /opt/scripts/bootstrap.sh

--- a/tyk-pro/scripts/init.sh
+++ b/tyk-pro/scripts/init.sh
@@ -6,5 +6,6 @@ apk --no-cache add curl jq
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
+echo "waiting for dashboard to be ready"
 while [[ $(kubectl get pod -n $TYK_POD_NAMESPACE -l app=$TYK_DASHBOARD_DEPLOY -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do sleep 10; done && \
 /opt/scripts/bootstrap.sh

--- a/tyk-pro/scripts/pre-delete.sh
+++ b/tyk-pro/scripts/pre-delete.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+apk --no-cache add curl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+if kubectl get secret -n "$TYK_POD_NAMESPACE" "$OPERATOR_SECRET_NAME"; then
+    echo "$OPERATOR_SECRET_NAME exists in $TYK_POD_NAMESPACE namespace, deleting $OPERATOR_SECRET_NAME"
+    kubectl delete secret -n "$TYK_POD_NAMESPACE" "$OPERATOR_SECRET_NAME"
+else
+    echo "$OPERATOR_SECRET_NAME does not exists in $TYK_POD_NAMESPACE namespace, skipping delete operation."
+fi

--- a/tyk-pro/scripts/pre-delete.sh
+++ b/tyk-pro/scripts/pre-delete.sh
@@ -12,3 +12,7 @@ if kubectl get secret -n "$TYK_POD_NAMESPACE" "$OPERATOR_SECRET_NAME"; then
 else
     echo "$OPERATOR_SECRET_NAME does not exists in $TYK_POD_NAMESPACE namespace, skipping delete operation."
 fi
+
+if kubectl delete jobs -n "$TYK_POD_NAMESPACE" bootstrap-post-install-tyk-pro; then
+    echo "Deleted existing bootstrap post install jobs"
+fi

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -18,8 +18,8 @@ You might want to install Tyk Operator next to manage Ingress resources or manag
 
 - If you enabled Tyk Operator secret bootstraping option (.Values.dash.operatorSecret), there is a secret named "tyk-operator-conf" used by our Tyk Operator in the namespace where you installed Tyk.
 This is created by default if you enabled the Dashboard bootstraping option (.Values.dash.bootstrap) and can be turned off by setting the .Values.dash.operatorSecret to false.
-
-If you have turned off "tyk-operator-conf" secret creation, you can create it as follows:
+{{ if not .Values.dash.operatorSecret }}
+You have turned off "tyk-operator-conf" secret creation. If you wish, you can create it as follows:
 kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
 	  --from-literal "TYK_AUTH=${USER_AUTH_CODE}" \
 	  --from-literal "TYK_ORG=${ORGID}" \
@@ -27,3 +27,4 @@ kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
 	  --from-literal "TYK_URL=${DASHBOARD_HOSTNAME}"
 
 You can access credentials for this secret through the dasboard. ${USER_AUTH_CODE} corresponds to Tyk Dashboard API Access Credentials and ${ORGID} corresponds to Organisation ID. 
+{{ end }}

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -16,5 +16,14 @@ You might want to install Tyk Operator next to manage Ingress resources or manag
 
 [Tyk Operator](https://github.com/TykTechnologies/tyk-operator/)
 
-- If you enabled Tyk Operator secret bootstraping option (.Values.dash.operatorSecret), inside tyk namespace there is secret named: "tyk-operator-conf", which is used by our Tyk Operator. 
+- If you enabled Tyk Operator secret bootstraping option (.Values.dash.operatorSecret), there is a secret named "tyk-operator-conf" used by our Tyk Operator in the namespace where you installed Tyk.
 This is created by default if you enabled the Dashboard bootstraping option (.Values.dash.bootstrap) and can be turned off by setting the .Values.dash.operatorSecret to false.
+
+If you have turned off "tyk-operator-conf" secret creation, you can create it as follows:
+kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
+	  --from-literal "TYK_AUTH=${USER_AUTH_CODE}" \
+	  --from-literal "TYK_ORG=${ORGID}" \
+	  --from-literal "TYK_MODE=pro" \
+	  --from-literal "TYK_URL=${DASHBOARD_HOSTNAME}"
+
+You can access credentials for this secret through the dasboard. ${USER_AUTH_CODE} corresponds to Tyk Dashboard API Access Credentials and ${ORGID} corresponds to Organisation ID. 

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -1,4 +1,4 @@
-- If you enabled the Dashboard bootstraping option (.Value.dash.bootstrap), you can find the login details by running the following commands inside your {{ .Release.Namespace }} namespace:
+- If you enabled the Dashboard bootstraping option (.Values.dash.bootstrap), you can find the login details by running the following commands inside your {{ .Release.Namespace }} namespace:
 
 For the URL: (kubectl get nodes --selector=kubernetes.io/role!=master -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}'), if you're using Minikube then: (minikube ip) would be sufficient"
 For the port: (kubectl get --namespace tyk -o jsonpath="{.spec.ports[0].nodePort}" services dashboard-svc-tyk-pro)"
@@ -16,5 +16,5 @@ You might want to install Tyk Operator next to manage Ingress resources or manag
 
 [Tyk Operator](https://github.com/TykTechnologies/tyk-operator/)
 
-Inside tyk namespace there is secret named: "tyk-operator-conf", which is used by our Tyk Operator. 
-This is created by default and can be tuned off by setting the .Values.bootstrap to false.
+- If you enabled Tyk Operator secret bootstraping option (.Values.dash.operatorSecret), inside tyk namespace there is secret named: "tyk-operator-conf", which is used by our Tyk Operator. 
+This is created by default if you enabled the Dashboard bootstraping option (.Values.dash.bootstrap) and can be turned off by setting the .Values.dash.operatorSecret to false.

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -10,14 +10,9 @@ For password: (kubectl get secret --namespace {{ .Release.Namespace }} {{ .Relea
 > URL can be accessed here: "{{ .Values.dash.hostName }}"
 > For the port run: (kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0]}" services dashboard-svc-{{ include "tyk-pro.fullname" . }})
 
-At this point, Tyk Pro is fully installed and should be accessible.
 
-You might want to install Tyk Operator next to manage Ingress resources or manage your APIs.
-
-[Tyk Operator](https://github.com/TykTechnologies/tyk-operator/)
-
-- If you enable (.Values.dash.operatorSecret) "tyk-operator-conf" secret, which is used by Tyk Operator, will be created in the {{ .Release.Namespace }} namespace.
-This is enabled by default if you have enabled the Dashboard bootstraping option (.Values.dash.bootstrap) and can be turned off by setting the .Values.dash.operatorSecret to false.
+- If you enable Tyk Operator secret option (.Values.dash.operatorSecret), during bootstrapping "tyk-operator-conf" secret will be created in the {{ .Release.Namespace }} namespace. This secret is used by Tyk Operator. 
+It is enabled by default and can be turned off by setting the .Values.dash.operatorSecret to false.
 {{ if not .Values.dash.operatorSecret }}
 You have turned off "tyk-operator-conf" secret creation. If you wish, you can create it as follows:
 kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
@@ -28,3 +23,9 @@ kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \
 
 You can access credentials for this secret through the dasboard. ${USER_AUTH_CODE} corresponds to Tyk Dashboard API Access Credentials and ${ORGID} corresponds to Organisation ID. 
 {{ end }}
+
+At this point, Tyk Pro is fully installed and should be accessible.
+
+You might want to install Tyk Operator next to manage Ingress resources or manage your APIs.
+
+[Tyk Operator](https://github.com/TykTechnologies/tyk-operator/)

--- a/tyk-pro/templates/NOTES.txt
+++ b/tyk-pro/templates/NOTES.txt
@@ -16,8 +16,8 @@ You might want to install Tyk Operator next to manage Ingress resources or manag
 
 [Tyk Operator](https://github.com/TykTechnologies/tyk-operator/)
 
-- If you enabled Tyk Operator secret bootstraping option (.Values.dash.operatorSecret), there is a secret named "tyk-operator-conf" used by our Tyk Operator in the namespace where you installed Tyk.
-This is created by default if you enabled the Dashboard bootstraping option (.Values.dash.bootstrap) and can be turned off by setting the .Values.dash.operatorSecret to false.
+- If you enable (.Values.dash.operatorSecret) "tyk-operator-conf" secret, which is used by Tyk Operator, will be created in the {{ .Release.Namespace }} namespace.
+This is enabled by default if you have enabled the Dashboard bootstraping option (.Values.dash.bootstrap) and can be turned off by setting the .Values.dash.operatorSecret to false.
 {{ if not .Values.dash.operatorSecret }}
 You have turned off "tyk-operator-conf" secret creation. If you wish, you can create it as follows:
 kubectl create secret -n ${TYK_POD_NAMESPACE} generic tyk-operator-conf \

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -17,7 +17,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 1
   template:
@@ -64,6 +64,10 @@ spec:
             value: {{ .Values.dash.org.cname | quote }}
           {{- if .Values.dash.enabled }}
           - name: DASHBOARD_ENABLED
+            value: "true"
+          {{- end }}
+          {{- if .Values.dash.operatorSecret }}
+          - name: OPERATOR_SECRET_ENABLED
             value: "true"
           {{- end }}
           {{- if .Values.dash.bootstrap }}

--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -69,6 +69,8 @@ spec:
           {{- if .Values.dash.operatorSecret }}
           - name: OPERATOR_SECRET_ENABLED
             value: "true"
+          - name: OPERATOR_SECRET_NAME
+            value: "tyk-operator-conf"
           {{- end }}
           {{- if .Values.dash.bootstrap }}
           - name: BOOTSTRAP_DASHBOARD

--- a/tyk-pro/templates/bootstrap-pre-delete.yaml
+++ b/tyk-pro/templates/bootstrap-pre-delete.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.bootstrap -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "bootstrap-pre-delete-{{ include "tyk-pro.fullname" . }}"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+
+    # Removed the use of appVersion since it's not accurate. We'll put it back in v1.0
+    # when every app will have its own a chart
+    # app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-6"
+
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      serviceAccountName: k8s-bootstrap-role
+      containers:
+        - name: bootstrap-pre-delete
+          image: bash:5.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - /opt/scripts/pre-delete.sh
+          env:
+            - name: OPERATOR_SECRET_NAME
+              value: "tyk-operator-conf"
+            - name: TYK_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: bootstrap-config-volume
+              mountPath: /opt/scripts
+      volumes:
+        - name: bootstrap-config-volume
+          configMap:
+            name: bootstrap-pre-delete-configmap-{{ include "tyk-pro.fullname" . }}
+            defaultMode: 0777
+      terminationGracePeriodSeconds: 0
+      restartPolicy: Never
+{{- end }}

--- a/tyk-pro/templates/bootstrap-pre-delete.yaml
+++ b/tyk-pro/templates/bootstrap-pre-delete.yaml
@@ -16,7 +16,7 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-weight": "0"
 
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:

--- a/tyk-pro/templates/bootstrap-role.yml
+++ b/tyk-pro/templates/bootstrap-role.yml
@@ -24,6 +24,11 @@ rules:
   - list
   - create
   - delete
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs:
+  - delete
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["get","update","patch"]

--- a/tyk-pro/templates/bootstrap-role.yml
+++ b/tyk-pro/templates/bootstrap-role.yml
@@ -12,11 +12,18 @@ rules:
   - services
   - pods
   - pods/exec
+  verbs:
+  - get
+  - list
+  - create
+- apiGroups: [""]
+  resources:
   - secrets
   verbs:
   - get
   - list
   - create
+  - delete
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["get","update","patch"]

--- a/tyk-pro/templates/configmap-pre-delete.yaml
+++ b/tyk-pro/templates/configmap-pre-delete.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bootstrap-pre-delete-configmap-{{ include "tyk-pro.fullname" . }}
+data:
+  pre-delete.sh: |-
+{{ .Files.Get "scripts/pre-delete.sh" | indent 4 }}

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -185,6 +185,12 @@ dash:
   enabled: true
   # Dashboard will only bootstrap if the master bootstrap option is set to true.
   bootstrap: true
+
+  # It creates a secret for Tyk Operator along with bootstraping dasboard. Operator Secret is only created if the dash.bootstrap
+  # and operatorSecret are set to true.
+  # Set false to disable creating a secret for Tyk Operator.
+  operatorSecret: true
+
   # The hostname to bind the Dashboard to.
   hostName: tyk-dashboard.local
   # If set to true the Dashboard will use SSL connection.


### PR DESCRIPTION
Current problem observed:
- `tyk-operator-conf` is not deleted if we do helm delete

- Failed Job doesn’t get deleted if we do helm delete. We end up with more jobs that fail

This PR adds 
- `before-hook-creation` to the delete policy of the post-install bootstrap. So that, jobs created by the bootstrap will be deleted either before a new hook is launched or successfully finished.
- new deletion hooks to clean up a secret of tyk-operator if it exists.
- new field called `operatorSecret` in the values.yaml. If it is set to true, `tyk-operator-conf` is created along with the dashboard bootstrap. Otherwise, it won't be created.