### PR TITLE
TT-6100 Update tyk-headless docs on Tyk GW deployment type

### DIFF
--- a/tyk-headless/README.md
+++ b/tyk-headless/README.md
@@ -19,7 +19,8 @@ helm repo update
 kubectl create namespace tyk
 helm install tyk-headless tyk-helm/tyk-headless -n tyk
 ```
-**NOTE**: By default, Gateway runs as DaemonSet. If you are using more than a Node, please update Gateway kind to `Deployment`. 
+**NOTE**: By default, Gateway runs as DaemonSet. If you are using more than a Node, please update Gateway kind to `Deployment` because multiple instances of headless gateways won't sync API Definition.
+
 To configure Gateway kind, do following changes in the `values.yaml` file:
 1. Save all options to a custom `values.yaml` file by running:
 ```bash

--- a/tyk-headless/README.md
+++ b/tyk-headless/README.md
@@ -19,6 +19,22 @@ helm repo update
 kubectl create namespace tyk
 helm install tyk-headless tyk-helm/tyk-headless -n tyk
 ```
+**NOTE**: By default, Gateway runs as DaemonSet. If you are using more than a Node, please update Gateway kind to `Deployment`. 
+To configure Gateway kind, do following changes in the `values.yaml` file:
+1. Save all options to a custom `values.yaml` file by running:
+```bash
+helm show values tyk-helm/tyk-headless > values.yaml
+```
+2. Update `.gateway.kind` field in the values.yaml to `Deployment`,
+3. Install `tyk-headless` using our custom values file:
+```bash
+helm install tyk-headless tyk-helm/tyk-headless -f values.yaml -n tyk
+```
+
+> Alternatively, you can use `--set gateway.kind=Deployment` while doing helm install.
+```bash
+helm install tyk-headless tyk-helm/tyk-headless --set gateway.kind=Deployment -n tyk
+```
 
 ## Pump Installation
 By default pump installation is disabled. You can enable it by setting `pump.enabled` to `true` in `values.yaml` file.


### PR DESCRIPTION
Signed-off-by: Burak Sekili <buraksekili@gmail.com>

<!-- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the headless chart's README to indicate the required steps to configure the Gateway deployment type.

By default, gateway is deployed as DaemonSet. Users might want to change it to Deployment type while using a multi-node environment for their headless GW. This PR adds instructions to show how to do required changes in the headless chart.

## Related Issue
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.