### PR TITLE
[TT-6473] Add hybrid pump to hybrid chart

### DIFF
--- a/tyk-hybrid/configs/pump_hybrid.conf
+++ b/tyk-hybrid/configs/pump_hybrid.conf
@@ -1,0 +1,35 @@
+{
+  "analytics_storage_type": "redis",
+  "analytics_storage_config": {
+    "type": "redis",
+    "host": "",
+    "port": 0,
+    "hosts": null,
+    "username": "",
+    "password": "",
+    "database": 0,
+    "optimisation_max_idle": 100,
+    "optimisation_max_active": 0,
+    "enable_cluster": false,
+    "redis_use_ssl": false,
+    "redis_ssl_insecure_skip_verify": false
+  },
+  "purge_delay": 5,
+  "health_check_endpoint_name": "hello",
+  "health_check_endpoint_port": 8083,
+  "pumps": {
+	"hybrid":{
+    "type": "hybrid",
+    "meta":{
+    "rpc_key": "",
+    "api_key": "",
+    "connection_string": "",
+    "use_ssl": false,
+    "ssl_insecure_skip_verify": false
+    }
+    }
+  },
+  "dont_purge_uptime_data": true,
+  "omit_detailed_recording": false,
+  "max_record_size": 1000
+}

--- a/tyk-hybrid/configs/tyk_pump_hybrid.conf
+++ b/tyk-hybrid/configs/tyk_pump_hybrid.conf
@@ -1,9 +1,10 @@
 {
+  "log_level": "info",
   "analytics_storage_type": "redis",
   "analytics_storage_config": {
     "type": "redis",
-    "host": "",
-    "port": 0,
+    "host": null,
+    "port": null,
     "hosts": null,
     "username": "",
     "password": "",
@@ -17,18 +18,7 @@
   "purge_delay": 5,
   "health_check_endpoint_name": "hello",
   "health_check_endpoint_port": 8083,
-  "pumps": {
-	"hybrid":{
-    "type": "hybrid",
-    "meta":{
-    "rpc_key": "",
-    "api_key": "",
-    "connection_string": "",
-    "use_ssl": false,
-    "ssl_insecure_skip_verify": false
-    }
-    }
-  },
+  "pumps": {},
   "dont_purge_uptime_data": true,
   "omit_detailed_recording": false,
   "max_record_size": 1000

--- a/tyk-hybrid/templates/configmap-pump.yaml
+++ b/tyk-hybrid/templates/configmap-pump.yaml
@@ -9,5 +9,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- (.Files.Glob "configs/pump_hybrid.conf").AsConfig | nindent 2 }}
+  {{- (.Files.Glob "configs/tyk_pump_hybrid.conf").AsConfig | nindent 2 }}
   {{- end }}

--- a/tyk-hybrid/templates/configmap-pump.yaml
+++ b/tyk-hybrid/templates/configmap-pump.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.pump.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pump-conf-{{ include "tyk-hybrid.fullname" . }}
+  labels:
+    app: pump-{{ include "tyk-hybrid.fullname" . }}
+    chart: {{ include "tyk-hybrid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- (.Files.Glob "configs/pump_hybrid.conf").AsConfig | nindent 2 }}
+  {{- end }}

--- a/tyk-hybrid/templates/deployment-pump.yaml
+++ b/tyk-hybrid/templates/deployment-pump.yaml
@@ -1,0 +1,128 @@
+{{- if .Values.pump.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pump-{{ include "tyk-hybrid.fullname" . }}
+  labels:
+    app: pump-{{ include "tyk-hybrid.fullname" . }}
+    chart: {{ include "tyk-hybrid.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.pump.replicaCount }}
+  selector:
+    matchLabels:
+      app: pump-{{ include "tyk-hybrid.fullname" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: pump-{{ include "tyk-hybrid.fullname" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-pump.yaml") . | sha256sum }}
+      {{- if .Values.pump.annotations }}
+      {{- range $key, $value := .Values.pump.annotations }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+    spec:
+  {{- if .Values.pump.nodeSelector }}
+nodeSelector:
+  {{ toYaml .Values.pump.nodeSelector | indent 8 }}
+  {{- end }}
+  {{- if .Values.pump.tolerations }}
+tolerations:
+  {{ toYaml .Values.pump.tolerations | indent 8 }}
+  {{- end }}
+  {{- if .Values.pump.affinity }}
+affinity:
+  {{ toYaml .Values.pump.affinity | indent 8 }}
+  {{- end }}
+containers:
+  - name: pump-{{ .Chart.Name }}
+    image: "{{ .Values.pump.image.repository }}:{{ .Values.pump.image.tag }}"
+    imagePullPolicy: {{ .Values.pump.image.pullPolicy }}
+    workingDir: "/opt/tyk-pump"
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      privileged: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - all
+    env:
+      # Legacy support for Redis Cluster driver. Driver dropped in v3.0.0.
+      - name: REDIGOCLUSTER_SHARDCOUNT
+        value: "128"
+
+      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_DATABASE
+        value: "{{ .Values.redis.storage.database }}"
+      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_REDISUSESSL
+        value: "{{ default "false" .Values.redis.useSSL }}"
+      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_ADDRS
+        value: {{ include "tyk-hybrid.redis_url" . | quote }}
+      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_ENABLECLUSTER
+        value: "{{ default "false" .Values.redis.enableCluster }}"
+      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-hybrid.fullname" . }} {{ end }}
+            key: redisPass
+      - name: TYK_PMP_PUMPS_HYBRID_TYPE
+        value: "hybrid"
+      - name: TYK_PMP_PUMPS_HYBRID_META_RPCKEY
+        valueFrom:
+          secretKeyRef:
+            name: { { if .Values.secrets.useSecretName } } { { .Values.secrets.useSecretName } } { { else } } secrets-{{ include "tyk-hybrid.fullname" . }} {{ end}}
+            key: rpcKey
+      - name: TYK_PMP_PUMPS_HYBRID_META_APIKEY
+        valueFrom:
+          secretKeyRef:
+            name: { { if .Values.secrets.useSecretName } } { { .Values.secrets.useSecretName } } { { else } } secrets-{{ include "tyk-hybrid.fullname" . }} {{ end}}
+            key: apiKey
+      - name: TYK_PMP_PUMPS_HYBRID_META_CONNECTIONSTRING
+        value: "{{ .Values.gateway.rpc.connString }}"
+      - name: TYK_PMP_PUMPS_HYBRID_META_AGGREGATED
+        value: "{{ .Values.pump.onlySendAggregates }}"
+      - name: TYK_PMP_PUMPS_HYBRID_META_USESSL
+        value: "{{ .Values.gateway.rpc.useSSL }}"
+      - name: TYK_PMP_PUMPS_HYBRID_META_SSLINSECURESKIPVERIFY
+        value: "{{ .Values.gateway.rpc.sslInsecureSkipVerify }}"
+      - name: TYK_PMP_PUMPS_HYBRID_META_GROUPID
+        value: "{{ .Values.gateway.rpc.groupId }}"
+
+      {{- if .Values.pump.extraEnvs }}
+      {{- toYaml .Values.pump.extraEnvs| nindent 10 }}
+      {{- end }}
+    command: ["/opt/tyk-pump/tyk-pump", "-c", "/etc/tyk-pump/pump.conf"]
+    volumeMounts:
+      - name: tyk-pump-conf
+        mountPath: /etc/tyk-pump
+      {{- if .Values.pump.mounts }}
+      {{- range $secret := .Values.pump.mounts }}
+      - name: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
+        mountPath: {{ $secret.mountPath }}
+      {{- end }}
+      {{- end }}
+    resources:
+  {{ toYaml .Values.pump.resources | indent 12 }}
+securityContext:
+  runAsUser: 1000
+  fsGroup: 2000
+volumes:
+  - name: tyk-pump-conf
+    configMap:
+      name: pump-conf-{{ include "tyk-hybrid.fullname" . }}
+      items:
+        - key: pump.conf
+          path: pump.conf
+  {{- if .Values.pump.mounts }}
+  {{- range $secret := .Values.pump.mounts }}
+  - name: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
+    secret:
+      secretName: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
+  {{- end }}
+  {{- end }}
+  {{- end}}

--- a/tyk-hybrid/templates/deployment-pump.yaml
+++ b/tyk-hybrid/templates/deployment-pump.yaml
@@ -23,106 +23,100 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-pump.yaml") . | sha256sum }}
       {{- if .Values.pump.annotations }}
       {{- range $key, $value := .Values.pump.annotations }}
-      {{ $key }}: {{ $value | quote }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}
     spec:
-  {{- if .Values.pump.nodeSelector }}
-nodeSelector:
-  {{ toYaml .Values.pump.nodeSelector | indent 8 }}
-  {{- end }}
-  {{- if .Values.pump.tolerations }}
-tolerations:
-  {{ toYaml .Values.pump.tolerations | indent 8 }}
-  {{- end }}
-  {{- if .Values.pump.affinity }}
-affinity:
-  {{ toYaml .Values.pump.affinity | indent 8 }}
-  {{- end }}
-containers:
-  - name: pump-{{ .Chart.Name }}
-    image: "{{ .Values.pump.image.repository }}:{{ .Values.pump.image.tag }}"
-    imagePullPolicy: {{ .Values.pump.image.pullPolicy }}
-    workingDir: "/opt/tyk-pump"
-    securityContext:
-      runAsNonRoot: true
-      allowPrivilegeEscalation: false
-      privileged: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-          - all
-    env:
-      # Legacy support for Redis Cluster driver. Driver dropped in v3.0.0.
-      - name: REDIGOCLUSTER_SHARDCOUNT
-        value: "128"
-
-      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_DATABASE
-        value: "{{ .Values.redis.storage.database }}"
-      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_REDISUSESSL
-        value: "{{ default "false" .Values.redis.useSSL }}"
-      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_ADDRS
-        value: {{ include "tyk-hybrid.redis_url" . | quote }}
-      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_ENABLECLUSTER
-        value: "{{ default "false" .Values.redis.enableCluster }}"
-      - name: TYK_PMP_ANALYTICSSTORAGECONFIG_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-hybrid.fullname" . }} {{ end }}
-            key: redisPass
-      - name: TYK_PMP_PUMPS_HYBRID_TYPE
-        value: "hybrid"
-      - name: TYK_PMP_PUMPS_HYBRID_META_RPCKEY
-        valueFrom:
-          secretKeyRef:
-            name: { { if .Values.secrets.useSecretName } } { { .Values.secrets.useSecretName } } { { else } } secrets-{{ include "tyk-hybrid.fullname" . }} {{ end}}
-            key: rpcKey
-      - name: TYK_PMP_PUMPS_HYBRID_META_APIKEY
-        valueFrom:
-          secretKeyRef:
-            name: { { if .Values.secrets.useSecretName } } { { .Values.secrets.useSecretName } } { { else } } secrets-{{ include "tyk-hybrid.fullname" . }} {{ end}}
-            key: apiKey
-      - name: TYK_PMP_PUMPS_HYBRID_META_CONNECTIONSTRING
-        value: "{{ .Values.gateway.rpc.connString }}"
-      - name: TYK_PMP_PUMPS_HYBRID_META_AGGREGATED
-        value: "{{ .Values.pump.onlySendAggregates }}"
-      - name: TYK_PMP_PUMPS_HYBRID_META_USESSL
-        value: "{{ .Values.gateway.rpc.useSSL }}"
-      - name: TYK_PMP_PUMPS_HYBRID_META_SSLINSECURESKIPVERIFY
-        value: "{{ .Values.gateway.rpc.sslInsecureSkipVerify }}"
-      - name: TYK_PMP_PUMPS_HYBRID_META_GROUPID
-        value: "{{ .Values.gateway.rpc.groupId }}"
-
-      {{- if .Values.pump.extraEnvs }}
-      {{- toYaml .Values.pump.extraEnvs| nindent 10 }}
-      {{- end }}
-    command: ["/opt/tyk-pump/tyk-pump", "-c", "/etc/tyk-pump/pump.conf"]
-    volumeMounts:
-      - name: tyk-pump-conf
-        mountPath: /etc/tyk-pump
-      {{- if .Values.pump.mounts }}
-      {{- range $secret := .Values.pump.mounts }}
-      - name: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
-        mountPath: {{ $secret.mountPath }}
-      {{- end }}
-      {{- end }}
-    resources:
-  {{ toYaml .Values.pump.resources | indent 12 }}
-securityContext:
-  runAsUser: 1000
-  fsGroup: 2000
-volumes:
-  - name: tyk-pump-conf
-    configMap:
-      name: pump-conf-{{ include "tyk-hybrid.fullname" . }}
-      items:
-        - key: pump.conf
-          path: pump.conf
-  {{- if .Values.pump.mounts }}
-  {{- range $secret := .Values.pump.mounts }}
-  - name: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
-    secret:
-      secretName: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
-  {{- end }}
-  {{- end }}
-  {{- end}}
+{{- if .Values.pump.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.pump.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.pump.tolerations }}
+      tolerations:
+{{ toYaml .Values.pump.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.pump.affinity }}
+      affinity:
+{{ toYaml .Values.pump.affinity | indent 8 }}
+{{- end }}
+      containers:
+      - name: pump-{{ .Chart.Name }}
+        image: "{{ .Values.pump.image.repository }}:{{ .Values.pump.image.tag }}"
+        imagePullPolicy: {{ .Values.pump.image.pullPolicy }}
+        workingDir: "/opt/tyk-pump"
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - all
+        env:
+          # Legacy support for Redis Cluster driver. Driver dropped in v3.0.0.
+          - name: REDIGOCLUSTER_SHARDCOUNT
+            value: "128"
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_DATABASE
+            value: "{{ .Values.redis.storage.database }}"
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_REDISUSESSL
+            value: "{{ default "false" .Values.redis.useSSL }}"
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_ADDRS
+            value: {{ include "tyk-hybrid.redis_url" . | quote }}
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_ENABLECLUSTER
+            value: "{{ default "false" .Values.redis.enableCluster }}"
+          - name: TYK_PMP_PUMPS_HYBRID_TYPE
+            value: "{{ default "hybrid" .Values.pump.type }}"
+          - name: TYK_PMP_PUMPS_HYBRID_META_USESSL
+            value: "{{ default "true" .Values.pump.useSSL }}"
+          - name: TYK_PMP_PUMPS_HYBRID_META_SSLINSECURESKIPVERIFY
+            value: "true"
+          - name: TYK_PMP_PUMPS_HYBRID_META_RPCKEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-hybrid.fullname" . }} {{ end}}
+                key: rpcKey
+          - name: TYK_PMP_PUMPS_HYBRID_META_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-hybrid.fullname" . }} {{ end}}
+                key: apiKey
+          - name: TYK_PMP_PUMPS_HYBRID_META_CONNECTIONSTRING
+            value: "{{ .Values.gateway.rpc.connString }}"
+          - name: TYK_PMP_ANALYTICSSTORAGECONFIG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-hybrid.fullname" . }} {{ end }}
+                key: redisPass
+          {{- if .Values.pump.extraEnvs }}
+          {{- toYaml .Values.pump.extraEnvs| nindent 10 }}
+          {{- end }}
+        command: ["/opt/tyk-pump/tyk-pump", "-c", "/etc/tyk-pump/pump.conf"]
+        volumeMounts:
+          - name: tyk-pump-conf
+            mountPath: /etc/tyk-pump
+          {{- if .Values.pump.mounts }}
+          {{- range $secret := .Values.pump.mounts }}
+          - name: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
+            mountPath: {{ $secret.mountPath }}
+          {{- end }}
+          {{- end }}
+        resources:
+{{ toYaml .Values.pump.resources | indent 12 }}
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
+      volumes:
+        - name: tyk-pump-conf
+          configMap:
+            name: pump-conf-{{ include "tyk-hybrid.fullname" . }}
+            items:
+              - key: tyk_pump_hybrid.conf
+                path: pump.conf
+        {{- if .Values.pump.mounts }}
+        {{- range $secret := .Values.pump.mounts }}
+        - name: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
+          secret:
+            secretName: {{ $.Release.Name }}-pump-secret-{{ $secret.name }}
+        {{- end }}
+        {{- end }}
+{{- end}}

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -131,46 +131,39 @@ gateway:
     #  cpu: 100m
     #  memory: 128Mi
     # requests:
-    #  cpu: 100m
+  #  cpu: 100m
   #  memory: 128Mi
   nodeSelector: {}
   tolerations:
     - key: node-role.kubernetes.io/master
       effect: NoSchedule
   affinity: {}
-  extraEnvs: []
+  extraEnvs: [
+    {
+      "name": "TYK_GW_ANALYTICSCONFIG_TYPE",
+      "value": ""
+    }
+  ]
   mounts: []
 
-
-  pump:
-    # Determines if the pump component should be installed.
-    enabled: true
-    onlySendAggregates: false
-
-
-    replicaCount: 1
-    image:
-      repository: tykio/tyk-pump-docker-pub
-      tag: v1.3
-      pullPolicy: Always
-    annotations: { }
-    resources: { }
-      # We usually recommend not to specify default resources and to leave this
-      # as a conscious choice for the user. This also increases chances charts
-      # run on environments with little resources, such as Minikube. If you do
-      # want to specify resources, uncomment the following lines, adjust them
-      # as necessary, and remove the curly braces after 'resources:'.
-      # limits:
-      #  cpu: 100m
-      #  memory: 128Mi
-      # requests:
-    #  cpu: 100m
-    #  memory: 128Mi
-    nodeSelector: { }
-    tolerations: [ ]
-    affinity: { }
-    extraEnvs: [ ]
-    mounts: [ ]
+pump:
+  # Determines if the pump component should be installed.
+  enabled: true
+  type: hybrid
+  useSSL: true
+  onlySendAggregates: false
+  replicaCount: 1
+  image:
+    repository: tykio/tyk-pump-docker-pub
+    tag: v1.6
+    pullPolicy: Always
+  annotations: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnvs: []
+  mounts: []
 
 rbac: true
 

--- a/tyk-hybrid/values.yaml
+++ b/tyk-hybrid/values.yaml
@@ -141,6 +141,37 @@ gateway:
   extraEnvs: []
   mounts: []
 
+
+  pump:
+    # Determines if the pump component should be installed.
+    enabled: true
+    onlySendAggregates: false
+
+
+    replicaCount: 1
+    image:
+      repository: tykio/tyk-pump-docker-pub
+      tag: v1.3
+      pullPolicy: Always
+    annotations: { }
+    resources: { }
+      # We usually recommend not to specify default resources and to leave this
+      # as a conscious choice for the user. This also increases chances charts
+      # run on environments with little resources, such as Minikube. If you do
+      # want to specify resources, uncomment the following lines, adjust them
+      # as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+    nodeSelector: { }
+    tolerations: [ ]
+    affinity: { }
+    extraEnvs: [ ]
+    mounts: [ ]
+
 rbac: true
 
 # deprecated - please use the rpcKey and apiKey in the gateway section


### PR DESCRIPTION

## Description

Current hybrid helm chart lacks the ability to natively run pump when you need it alongside your hybrid gateway.



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.