### PR TITLE
TT-7028 Fix support for bool values

### DIFF
--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -132,9 +132,12 @@ spec:
         {{- end }}
           - name: TYK_GW_HTTPSERVEROPTIONS_USESSL
             value: "{{ .Values.gateway.tls }}"
-          {{- if .Values.gateway.extraEnvs }}
-          {{- toYaml .Values.gateway.extraEnvs| nindent 10 }}
-          {{- end }}
+        {{- if .Values.gateway.extraEnvs }}
+        {{- range $env := .Values.gateway.extraEnvs }}
+          - name: {{ $env.name }}
+            value: {{ $env.value | quote }}
+        {{- end }}
+        {{- end }}
         command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
         workingDir: /opt/tyk-gateway
         ports:

--- a/tyk-pro/templates/deployment-mdcb.yaml
+++ b/tyk-pro/templates/deployment-mdcb.yaml
@@ -89,9 +89,12 @@ spec:
               secretKeyRef:
                 name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-pro.fullname" . }} {{ end}}
                 key: MDCBLicense
-          {{- if .Values.mdcb.extraEnvs }}
-          {{- toYaml .Values.mdcb.extraEnvs| nindent 10 }}
-          {{- end }}
+        {{- if .Values.mdcb.extraEnvs }}
+        {{- range $env := .Values.mdcb.extraEnvs }}
+          - name: {{ $env.name }}
+            value: {{ $env.value | quote }}
+        {{- end }}
+        {{- end }}
         resources:
         {{ toYaml .Values.mdcb.resources | indent 12 }}
         command: ["/opt/tyk-sink/tyk-sink", "--c=/etc/tyk-sink/tyk_sink.conf"]

--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -138,10 +138,12 @@ spec:
                 name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-pro.fullname" . }} {{ end }}
                 key: mongoURL
           {{ end }}
- 
-          {{- if .Values.pump.extraEnvs }}
-          {{- toYaml .Values.pump.extraEnvs| nindent 10 }}
-          {{- end }}
+        {{- if .Values.pump.extraEnvs }}
+        {{- range $env := .Values.pump.extraEnvs }}
+          - name: {{ $env.name }}
+            value: {{ $env.value | quote }}
+        {{- end }}
+        {{- end }}
         command: ["/opt/tyk-pump/tyk-pump", "-c", "/etc/tyk-pump/pump.conf"]
         volumeMounts:
           - name: tyk-pump-conf

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -82,9 +82,12 @@ spec:
             value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
           - name: TYK_IB_TYKAPISETTINGS_DASHBOARDCONFIG_PORT
             value: "{{ .Values.dash.service.port }}"
-          {{- if .Values.tib.extraEnvs }}
-          {{- toYaml .Values.tib.extraEnvs| nindent 10 }}
-          {{- end }}
+        {{- if .Values.tib.extraEnvs }}
+        {{- range $env := .Values.tib.extraEnvs }}
+          - name: {{ $env.name }}
+            value: {{ $env.value | quote }}
+        {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.tib.resources | indent 10 }}
         ports:

--- a/tyk-pro/templates/statefulset-enterprise-portal.yaml
+++ b/tyk-pro/templates/statefulset-enterprise-portal.yaml
@@ -88,9 +88,12 @@ spec:
               secretKeyRef:
                 name: tyk-enterprise-portal-conf
                 key: TYK_ORG
-          {{- if .Values.enterprisePortal.extraEnvs }}
-          {{- toYaml .Values.enterprisePortal.extraEnvs| nindent 10 }}
-          {{- end }}
+        {{- if .Values.enterprisePortal.extraEnvs }}
+        {{- range $env := .Values.enterprisePortal.extraEnvs }}
+          - name: {{ $env.name }}
+            value: {{ $env.value | quote }}
+        {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.enterprisePortal.resources | indent 12 }}
         command: ["/opt/portal/dev-portal"]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Currently if we try to set an extraEnv that is a bool variable the helm charts will fail...

`failed to create resource: Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string`

## Motivation and Context
Such sets will fail...
  --set "mdcb.extraEnvs[0].name=TYK_MDCB_SYNCWORKER_ENABLED" \
  --set "mdcb.extraEnvs[0].value=true" \
  --set "mdcb.extraEnvs[1].name=TYK_MDCB_SYNCWORKER_HASHKEYS" \
  --set "mdcb.extraEnvs[1].value=true" \

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [ ] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.