### PR TITLE
TT-7030 fix probes in headless for v4+

### DIFF
--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -158,7 +158,7 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
-            {{- if and .Values.gateway.control.enabled (or (semverCompare "^3.2.x" (include "tyk-headless.gateway-version" . )) (semverCompare ">=3.0.4 < 3.1.0" (include "tyk-headless.gateway-version" .))) }}
+            {{- if and .Values.gateway.control.enabled (or (semverCompare ">= 3.2.0" (include "tyk-headless.gateway-version" . )) (semverCompare ">=3.0.4 < 3.1.0" (include "tyk-headless.gateway-version" .))) }}
             port: {{ .Values.gateway.control.containerPort }}
             {{- else }}
             port: {{ .Values.gateway.containerPort }}
@@ -171,7 +171,7 @@ spec:
           httpGet:
             scheme: "HTTP{{ if .Values.gateway.tls }}S{{ end }}"
             path: /hello
-            {{- if and .Values.gateway.control.enabled (or (semverCompare "^3.2.x" (include "tyk-headless.gateway-version" . )) (semverCompare ">=3.0.4 < 3.1.0" (include "tyk-headless.gateway-version" .))) }}
+            {{- if and .Values.gateway.control.enabled (or (semverCompare ">= 3.2.0" (include "tyk-headless.gateway-version" . )) (semverCompare ">=3.0.4 < 3.1.0" (include "tyk-headless.gateway-version" .))) }}
             port: {{ .Values.gateway.control.containerPort }}
             {{- else }}
             port: {{ .Values.gateway.containerPort }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Fixing `livenessProbe` & `readinessProbe` port when `gateway.control.enabled` and version is 4+.

## Related Issue
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.