### PR TITLE
[TT-7211] Fix headless templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/TykTechnologies/tyk-helm-chart/tree/HEAD)
 
+**Update:**
+- Check mongo and redis fields is not nil before using it's child fields
+
 ## [v0.13.0](https://github.com/TykTechnologies/tyk-helm-chart/tree/HEAD)
 
 [Full Changelog](https://github.com/TykTechnologies/tyk-helm-chart/compare/v0.12.0...v0.13.0)

--- a/tyk-headless/templates/_helpers.tpl
+++ b/tyk-headless/templates/_helpers.tpl
@@ -49,11 +49,13 @@ redis.{{ .Release.Namespace }}.svc.cluster.local:6379
 
 {{- define "tyk-headless.mongo_url" -}}
 {{- if .Values.pump.enabled -}}
+{{- if .Values.mongo -}}
 {{- if .Values.mongo.mongoURL -}}
 {{ .Values.mongo.mongoURL }}
 {{- /* Adds support for older charts with the host and port options */}}
 {{- else if and .Values.mongo.host .Values.mongo.port -}}
 mongodb://{{ .Values.mongo.host }}:{{ .Values.mongo.port }}/tyk_analytics
+{{- end -}}
 {{- else -}}
 mongodb://mongo.{{ .Release.Namespace }}.svc.cluster.local:27017/tyk_analytics
 {{- end -}}

--- a/tyk-headless/templates/_helpers.tpl
+++ b/tyk-headless/templates/_helpers.tpl
@@ -48,6 +48,7 @@ redis.{{ .Release.Namespace }}.svc.cluster.local:6379
 {{- end -}}
 
 {{- define "tyk-headless.mongo_url" -}}
+{{- if .Values.pump.enabled -}}
 {{- if .Values.mongo.mongoURL -}}
 {{ .Values.mongo.mongoURL }}
 {{- /* Adds support for older charts with the host and port options */}}
@@ -55,6 +56,7 @@ redis.{{ .Release.Namespace }}.svc.cluster.local:6379
 mongodb://{{ .Values.mongo.host }}:{{ .Values.mongo.port }}/tyk_analytics
 {{- else -}}
 mongodb://mongo.{{ .Release.Namespace }}.svc.cluster.local:27017/tyk_analytics
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/tyk-headless/templates/_helpers.tpl
+++ b/tyk-headless/templates/_helpers.tpl
@@ -48,16 +48,12 @@ redis.{{ .Release.Namespace }}.svc.cluster.local:6379
 {{- end -}}
 
 {{- define "tyk-headless.mongo_url" -}}
-{{- if .Values.pump.enabled -}}
-{{- if .Values.mongo -}}
+{{- if and .Values.pump.enabled .Values.mongo -}}
 {{- if .Values.mongo.mongoURL -}}
 {{ .Values.mongo.mongoURL }}
 {{- /* Adds support for older charts with the host and port options */}}
 {{- else if and .Values.mongo.host .Values.mongo.port -}}
 mongodb://{{ .Values.mongo.host }}:{{ .Values.mongo.port }}/tyk_analytics
-{{- end -}}
-{{- else -}}
-mongodb://mongo.{{ .Release.Namespace }}.svc.cluster.local:27017/tyk_analytics
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/tyk-headless/templates/_helpers.tpl
+++ b/tyk-headless/templates/_helpers.tpl
@@ -48,13 +48,15 @@ redis.{{ .Release.Namespace }}.svc.cluster.local:6379
 {{- end -}}
 
 {{- define "tyk-headless.mongo_url" -}}
-{{- if and .Values.pump.enabled .Values.mongo -}}
+{{- if .Values.mongo -}}
 {{- if .Values.mongo.mongoURL -}}
 {{ .Values.mongo.mongoURL }}
 {{- /* Adds support for older charts with the host and port options */}}
 {{- else if and .Values.mongo.host .Values.mongo.port -}}
 mongodb://{{ .Values.mongo.host }}:{{ .Values.mongo.port }}/tyk_analytics
 {{- end -}}
+{{- else -}}
+mongodb://mongo.{{ .Release.Namespace }}.svc.cluster.local:27017/tyk_analytics
 {{- end -}}
 {{- end -}}
 

--- a/tyk-headless/templates/_helpers.tpl
+++ b/tyk-headless/templates/_helpers.tpl
@@ -43,9 +43,9 @@ Create chart name and version as used by the chart label.
 {{- /* Adds support for older charts with the host and port options */}}
 {{- else if and .Values.redis.host .Values.redis.port -}}
 {{ .Values.redis.host }}:{{ .Values.redis.port }}
-{{- end -}}
 {{- else -}}
 redis.{{ .Release.Namespace }}.svc.cluster.local:6379
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -56,9 +56,9 @@ redis.{{ .Release.Namespace }}.svc.cluster.local:6379
 {{- /* Adds support for older charts with the host and port options */}}
 {{- else if and .Values.mongo.host .Values.mongo.port -}}
 mongodb://{{ .Values.mongo.host }}:{{ .Values.mongo.port }}/tyk_analytics
-{{- end -}}
 {{- else -}}
 mongodb://mongo.{{ .Release.Namespace }}.svc.cluster.local:27017/tyk_analytics
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/tyk-headless/templates/_helpers.tpl
+++ b/tyk-headless/templates/_helpers.tpl
@@ -37,11 +37,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "tyk-headless.redis_url" -}}
+{{- if .Values.redis -}}
 {{- if .Values.redis.addrs -}}
 {{ join "," .Values.redis.addrs }}
 {{- /* Adds support for older charts with the host and port options */}}
 {{- else if and .Values.redis.host .Values.redis.port -}}
 {{ .Values.redis.host }}:{{ .Values.redis.port }}
+{{- end -}}
 {{- else -}}
 redis.{{ .Release.Namespace }}.svc.cluster.local:6379
 {{- end -}}

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -91,6 +91,8 @@ spec:
             value: "128"
           - name: TYK_GW_STORAGE_ADDRS
             value: {{ include "tyk-headless.redis_url" . | quote }}
+
+          {{ if .Values.redis }}
           {{ if .Values.redis.enableSentinel }}
           - name: TYK_GW_STORAGE_SENTINELPASSWORD
             valueFrom:
@@ -117,6 +119,8 @@ spec:
                 key: redisPass
           - name: TYK_GW_STORAGE_USESSL
             value: "{{ default "false" .Values.redis.useSSL }}"
+          {{- end -}}
+
           - name: TYK_GW_SECRET
             valueFrom:
               secretKeyRef:

--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -119,7 +119,7 @@ spec:
                 key: redisPass
           - name: TYK_GW_STORAGE_USESSL
             value: "{{ default "false" .Values.redis.useSSL }}"
-          {{- end -}}
+          {{ end }}
 
           - name: TYK_GW_SECRET
             valueFrom:

--- a/tyk-headless/templates/secrets.yaml
+++ b/tyk-headless/templates/secrets.yaml
@@ -10,8 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
+  {{ if .Values.redis }}
   redisPass: "{{ .Values.redis.pass }}"
   redisSentinelPass: "{{ .Values.redis.sentinelPass }}"
+  {{ end }}
   mongoURL: {{ include "tyk-headless.mongo_url" . | quote }}
   pgConnectionString: {{ include "tyk-headless.pg_connection_string" . }}
   APISecret: "{{ .Values.secrets.APISecret }}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Validate `redis` and `mongo` fields are not nil before accessing it's child fields

## Related Issue
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
[TT-7211](https://tyktech.atlassian.net/browse/TT-7211)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Installation was successful with empty `mongo` and `redis` fields.

## Screenshots (if appropriate)

## Types of changesmpaty m
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.