### PR TITLE
TT-7322 - Allow valueFrom in extraEnvs

### DIFF
--- a/tyk-headless/templates/deployment-gw-repset.yaml
+++ b/tyk-headless/templates/deployment-gw-repset.yaml
@@ -137,12 +137,9 @@ spec:
           - name: TYK_GW_ENABLEANALYTICS
             value: "true"
             {{- end }}
-        {{- if .Values.gateway.extraEnvs }}
-        {{- range $env := .Values.gateway.extraEnvs }}
-          - name: {{ $env.name }}
-            value: {{ $env.value | quote }}
-        {{- end }}
-        {{- end }}
+          {{- with .Values.gateway.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
         workingDir: /opt/tyk-gateway
         ports:

--- a/tyk-headless/templates/deployment-pmp.yaml
+++ b/tyk-headless/templates/deployment-pmp.yaml
@@ -155,12 +155,9 @@ spec:
                 key: redisPass
           - name: TYK_PMP_ANALYTICSSTORAGECONFIG_REDISUSESSL
             value: "{{ default "false" .Values.redis.useSSL }}"
-        {{- if .Values.pump.extraEnvs }}
-        {{- range $env := .Values.pump.extraEnvs }}
-          - name: {{ $env.name }}
-            value: {{ $env.value | quote }}
-        {{- end }}
-        {{- end }}
+          {{- with .Values.pump.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         command: ["/opt/tyk-pump/tyk-pump", "-c", "/etc/tyk-pump/pump.conf"]
         volumeMounts:
           - name: tyk-pump-conf

--- a/tyk-hybrid/templates/deployment-gw-repset.yaml
+++ b/tyk-hybrid/templates/deployment-gw-repset.yaml
@@ -137,12 +137,9 @@ spec:
             value: "{{ .Values.gateway.tags }}"
             {{- end }}
         {{- end }}
-        {{- if .Values.gateway.extraEnvs }}
-        {{- range $env := .Values.gateway.extraEnvs }}
-          - name: {{ $env.name }}
-            value: {{ $env.value | quote }}
-        {{- end }}
-        {{- end }}
+          {{- with .Values.gateway.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
         workingDir: /opt/tyk-gateway
         ports:

--- a/tyk-pro/templates/deployment-dash.yaml
+++ b/tyk-pro/templates/deployment-dash.yaml
@@ -163,8 +163,8 @@ spec:
           - name: TYK_DB_MONGOUSESSL
             value: "{{ default "false" .Values.mongo.useSSL }}"
           {{ end }}
-          {{- if .Values.dash.extraEnvs }}
-          {{- toYaml .Values.dash.extraEnvs| nindent 10 }}
+          {{- with .Values.dash.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
         resources:
 {{ toYaml .Values.dash.resources | indent 12 }}

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -139,12 +139,9 @@ spec:
         {{- end }}
           - name: TYK_GW_HTTPSERVEROPTIONS_USESSL
             value: "{{ .Values.gateway.tls }}"
-        {{- if .Values.gateway.extraEnvs }}
-        {{- range $env := .Values.gateway.extraEnvs }}
-          - name: {{ $env.name }}
-            value: {{ $env.value | quote }}
-        {{- end }}
-        {{- end }}
+          {{- with .Values.gateway.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         command: ["/opt/tyk-gateway/tyk", "--conf=/etc/tyk-gateway/tyk.conf"]
         workingDir: /opt/tyk-gateway
         ports:

--- a/tyk-pro/templates/deployment-mdcb.yaml
+++ b/tyk-pro/templates/deployment-mdcb.yaml
@@ -98,12 +98,9 @@ spec:
               secretKeyRef:
                 name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-pro.fullname" . }} {{ end}}
                 key: MDCBLicense
-        {{- if .Values.mdcb.extraEnvs }}
-        {{- range $env := .Values.mdcb.extraEnvs }}
-          - name: {{ $env.name }}
-            value: {{ $env.value | quote }}
-        {{- end }}
-        {{- end }}
+          {{- with .Values.mdcb.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         resources:
         {{ toYaml .Values.mdcb.resources | indent 12 }}
         command: ["/opt/tyk-sink/tyk-sink", "--c=/etc/tyk-sink/tyk_sink.conf"]

--- a/tyk-pro/templates/deployment-pmp.yaml
+++ b/tyk-pro/templates/deployment-pmp.yaml
@@ -144,12 +144,9 @@ spec:
                 name: {{ if .Values.secrets.useSecretName }} {{ .Values.secrets.useSecretName }} {{ else }} secrets-{{ include "tyk-pro.fullname" . }} {{ end }}
                 key: mongoURL
           {{ end }}
-        {{- if .Values.pump.extraEnvs }}
-        {{- range $env := .Values.pump.extraEnvs }}
-          - name: {{ $env.name }}
-            value: {{ $env.value | quote }}
-        {{- end }}
-        {{- end }}
+          {{- with .Values.pump.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         command: ["/opt/tyk-pump/tyk-pump", "-c", "/etc/tyk-pump/pump.conf"]
         volumeMounts:
           - name: tyk-pump-conf

--- a/tyk-pro/templates/deployment-tib.yaml
+++ b/tyk-pro/templates/deployment-tib.yaml
@@ -88,12 +88,9 @@ spec:
             value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}"
           - name: TYK_IB_TYKAPISETTINGS_DASHBOARDCONFIG_PORT
             value: "{{ .Values.dash.service.port }}"
-        {{- if .Values.tib.extraEnvs }}
-        {{- range $env := .Values.tib.extraEnvs }}
-          - name: {{ $env.name }}
-            value: {{ $env.value | quote }}
-        {{- end }}
-        {{- end }}
+          {{- with .Values.tib.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         resources:
 {{ toYaml .Values.tib.resources | indent 10 }}
         ports:


### PR DESCRIPTION
## Description
Allow valueFrom in the extraEnvs sections of values.yaml.
This will add the ability to securely add secrets to the environment variables.

## Related Issue
https://github.com/TykTechnologies/tyk-helm-chart/issues/246

## Motivation and Context
The current implementation is very limiting.

## Test Coverage For This Change
Tested the new code only for the tyk-pro pump deployment template.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.