### PR TITLE
[TT-9165] Make initialDelaySeconds configurable for enterprise portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## [Unreleased](https://github.com/TykTechnologies/tyk-helm-chart/tree/HEAD)
-[Full Changelog](https://github.com/TykTechnologies/tyk-helm-chart/compare/v0.13.2...HEAD)
+[Full Changelog](https://github.com/TykTechnologies/tyk-helm-chart/compare/v0.14.0...HEAD)
+
+**Updated**:
+- Default initialDelaySeconds of liveness and readiness probe of enterprise portal is changed to 60s.
+- InitialDelaySeconds of liveness and readiness probe of enterprise portal can be configured from values file.
 
 ## [v0.14.0](https://github.com/TykTechnologies/tyk-helm-chart/tree/HEAD)
 

--- a/tyk-pro/templates/statefulset-enterprise-portal.yaml
+++ b/tyk-pro/templates/statefulset-enterprise-portal.yaml
@@ -149,7 +149,7 @@ spec:
             scheme: "HTTP{{ if .Values.enterprisePortal.tls }}S{{ end }}"
             path: /
             port: {{ .Values.enterprisePortal.containerPort }}
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
           periodSeconds: 2
           timeoutSeconds: 3
           failureThreshold: 2
@@ -158,7 +158,7 @@ spec:
             scheme: "HTTP{{ if .Values.enterprisePortal.tls }}S{{ end }}"
             path: /
             port: {{ .Values.enterprisePortal.containerPort }}
-          initialDelaySeconds: 1
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3

--- a/tyk-pro/templates/statefulset-enterprise-portal.yaml
+++ b/tyk-pro/templates/statefulset-enterprise-portal.yaml
@@ -149,7 +149,7 @@ spec:
             scheme: "HTTP{{ if .Values.enterprisePortal.tls }}S{{ end }}"
             path: /
             port: {{ .Values.enterprisePortal.containerPort }}
-          initialDelaySeconds: 60
+          initialDelaySeconds: {{ default 60 .Values.enterprisePortal.livenessProbe.initialDelaySeconds}}
           periodSeconds: 2
           timeoutSeconds: 3
           failureThreshold: 2
@@ -158,7 +158,7 @@ spec:
             scheme: "HTTP{{ if .Values.enterprisePortal.tls }}S{{ end }}"
             path: /
             port: {{ .Values.enterprisePortal.containerPort }}
-          initialDelaySeconds: 60
+          initialDelaySeconds: {{ default 60 .Values.enterprisePortal.readinessProbe.initialDelaySeconds}}
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 3

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -373,6 +373,15 @@ enterprisePortal:
   adminUser:
     email: default@example.com
     password: topsecretpassword
+
+  # Configure liveness probe fields of enterprise portal
+  livenessProbe:
+    initialDelaySeconds: 60
+
+  # Configure readiness probe fields of enterprise portal
+  readinessProbe:
+    initialDelaySeconds: 60
+
   storage:
     database:
       type: postgres

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -360,7 +360,7 @@ enterprisePortal:
   # Determines whether or not the enterprise portal component should be installed.
   enabled: false
 
-  # Eenterprise Portal will only bootstrap if the tyk-enterprise-portal-conf secret
+  # Enterprise Portal will only bootstrap if the tyk-enterprise-portal-conf secret
   # is present. The secret is created during the dashboard bootstraping and
   # be turned on and off using the dash.enterprisePortalSecret bool.
   bootstrap: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
- Changed default initialDelaySeconds for probes of enterprise portal to 60s
- Made it configurable.

## Related Issue
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
[TT-9165](https://tyktech.atlassian.net/browse/TT-9165)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[TT-9165]: https://tyktech.atlassian.net/browse/TT-9165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ