### PR TITLE
TT-10382 Make bootstrap job images configurable

### DIFF
--- a/tyk-pro/templates/bootstrap-post-install.yaml
+++ b/tyk-pro/templates/bootstrap-post-install.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name:  {{ .Values.jobs.bootstrapJobName }}
+  name:  {{ .Values.jobs.bootstrapPostInstallJob.name }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: k8s-bootstrap-role
       containers:
         - name: bootstrap-tyk-post-install
-          image: tykio/tyk-k8s-bootstrap-post:latest
+          image: "{{ .Values.jobs.bootstrapPostInstallJob.image.repository }}:{{ .Values.jobs.bootstrapPostInstallJob.image.tag }}"
           command: [ './app/bin/bootstrap-app-post' ]
           imagePullPolicy: IfNotPresent
           env:
@@ -92,4 +92,4 @@ spec:
       restartPolicy: Never
       terminationGracePeriodSeconds: 0
 {{- end }}
-      
+

--- a/tyk-pro/templates/bootstrap-pre-delete.yaml
+++ b/tyk-pro/templates/bootstrap-pre-delete.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: k8s-bootstrap-role
       containers:
         - name: bootstrap-tyk-pre-delete
-          image: tykio/tyk-k8s-bootstrap-pre-delete:latest
+          image: "{{ .Values.jobs.bootstrapPreDeleteJob.image.repository }}:{{ .Values.jobs.bootstrapPreDeleteJob.image.tag }}"
           command: [ './app/bin/bootstrap-app-pre-delete' ]
           imagePullPolicy: IfNotPresent
           env:
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: BOOTSTRAP_JOB_NAME
-              value: {{ .Values.jobs.bootstrapJobName }}
+              value: {{ .Values.jobs.bootstrapPostInstallJob.name }}
       terminationGracePeriodSeconds: 0
       restartPolicy: Never
 {{- end }}

--- a/tyk-pro/values.yaml
+++ b/tyk-pro/values.yaml
@@ -20,7 +20,15 @@ bootstrap: true
 
 # Settings related to k8s that are ran when installing the tyk stack
 jobs:
-  bootstrapJobName: bootstrap-post-install
+  bootstrapPostInstallJob:
+    name: bootstrap-post-install
+    image:
+      repository: tykio/tyk-k8s-bootstrap-post
+      tag: latest
+  bootstrapPreDeleteJob:
+    image:
+      repository: tykio/tyk-k8s-bootstrap-pre-delete
+      tag: latest
 
 
 # These are your Tyk stack secrets will directly map to the following


### PR DESCRIPTION
Make bootstrap job images configurable in tyk-pro chart

## Description
Restructured values file a bit to make it possible to also add configuration for bootstrap job images. 

## Related Issue

https://github.com/TykTechnologies/tyk-helm-chart/issues/290

## Motivation and Context
If using private docker registries with mirrored images it is not possible to pull from dockerhub, therefor the images in the bootstrap job are needed to be configurable, as all other images in the chart.

## Test Coverage For This Change
Did helm template and compared with previous version. Only difference is an autogenerated password, TYK_PASS.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.