### PR TITLE
updated the path to the value of the tib service port

### DIFF
--- a/tyk-pro/templates/ingress-tib.yaml
+++ b/tyk-pro/templates/ingress-tib.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.tib.enabled .Values.tib.ingress.enabled -}}
 {{- $fullName := include "tyk-pro.fullname" . -}}
-{{- $svcPort := .Values.dash.service.port -}}
+{{- $svcPort := .Values.tib.service.port -}}
 {{- if and .Values.tib.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.tib.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.tib.ingress.annotations "kubernetes.io/ingress.class" .Values.tib.ingress.className}}


### PR DESCRIPTION
## Description
Fixed a the value used for the stand alone tib ingress route, as here the value of the dashboard is used.

## Related Issue
- Setup standalone tib and try use it.
- you will get timeouts as the the wrong service port is used

## Motivation and Context
Makes the stand alone tib usable


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.